### PR TITLE
fix(mobile): fix missing section titles and article card overflow on mobile

### DIFF
--- a/src/components/AnimatedHeading/index.tsx
+++ b/src/components/AnimatedHeading/index.tsx
@@ -9,9 +9,6 @@ interface Props {
 export default function AnimatedHeading({ children, className = '' }: Props) {
   return (
     <motion.h3
-      initial="hidden"
-      whileInView="visible"
-      viewport={{ once: true, margin: '-40px' }}
       variants={{
         hidden: { clipPath: 'inset(0 100% 0 0)' },
         visible: {
@@ -19,7 +16,7 @@ export default function AnimatedHeading({ children, className = '' }: Props) {
           transition: { duration: 0.8, ease: 'easeOut' },
         },
       }}
-      className={`relative mb-3 inline-block text-xl font-semibold text-black dark:text-white md:text-4xl ${className}`}
+      className={`relative mb-3 block text-xl font-semibold text-black dark:text-white md:text-4xl ${className}`}
     >
       {children}
       <motion.span

--- a/src/components/ArticleGrid/index.tsx
+++ b/src/components/ArticleGrid/index.tsx
@@ -29,10 +29,10 @@ export default function ArticleGrid({ articles }: Props) {
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: '-50px' }}
-        className="my-2 flex w-full flex-wrap justify-items-start gap-1.5"
+        className="my-2 flex w-full flex-wrap justify-start gap-1.5"
       >
         {articles.map((article) => (
-          <motion.div key={article.id} variants={itemVariants}>
+          <motion.div key={article.id} variants={itemVariants} className="min-w-0 w-full md:w-auto">
             <ArticleCard article={article} />
           </motion.div>
         ))}

--- a/src/components/ProjectGrid/index.tsx
+++ b/src/components/ProjectGrid/index.tsx
@@ -41,10 +41,10 @@ export default function ProjectGrid({
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: '-50px' }}
-        className="my-2 flex w-full flex-wrap justify-items-start gap-1.5"
+        className="my-2 flex w-full flex-wrap justify-start gap-1.5"
       >
         {items.slice(0, visibleItems).map((item, index) => (
-          <motion.div key={index} variants={itemVariants}>
+          <motion.div key={index} variants={itemVariants} className="min-w-0 w-full md:w-auto">
             <ProjectCard {...item} />
           </motion.div>
         ))}


### PR DESCRIPTION
- AnimatedHeading: remove independent whileInView trigger; rely on parent
  Reveal variant propagation so clipPath animation always fires correctly.
  Also change inline-block to block so titles span full container width.
- ArticleGrid/ProjectGrid: add w-full md:w-auto min-w-0 to per-card wrappers
  so cards fill the screen on mobile instead of overflowing.
- Fix invalid justify-items-start (grid property) to justify-start (flex).

https://claude.ai/code/session_013UMvfhxLtBS2219LR14MSC