### PR TITLE
Add accessibility tags and support

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -247,5 +247,8 @@
     "reading": "Reading",
     "relatedLabel": "more",
     "relatedTitle": "Recent writing"
+  },
+  "a11y": {
+    "skipToContent": "Skip to content"
   }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -247,5 +247,8 @@
     "reading": "Leitura",
     "relatedLabel": "mais",
     "relatedTitle": "Artigos recentes"
+  },
+  "a11y": {
+    "skipToContent": "Pular para o conteúdo"
   }
 }

--- a/src/__tests__/components/ScrollToTopButton.test.tsx
+++ b/src/__tests__/components/ScrollToTopButton.test.tsx
@@ -6,21 +6,18 @@ import ScrollToTopButton from '@/components/ScrollToTopButton';
 describe('ScrollToTopButton', () => {
   it('should be visible when isVisible is true', () => {
     render(<ScrollToTopButton isVisible={true} scrollToTop={jest.fn()} />);
-    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(screen.getByLabelText('Scroll to top')).toBeInTheDocument();
   });
 
   it('should be invisible when isVisible is false', () => {
     render(<ScrollToTopButton isVisible={false} scrollToTop={jest.fn()} />);
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Scroll to top')).not.toBeInTheDocument();
   });
 
   it('should call scrollToTop when clicked', () => {
     const scrollToTop = jest.fn();
-    const { container } = render(
-      <ScrollToTopButton isVisible={true} scrollToTop={scrollToTop} />
-    );
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(container.firstChild as HTMLElement);
+    render(<ScrollToTopButton isVisible={true} scrollToTop={scrollToTop} />);
+    fireEvent.click(screen.getByLabelText('Scroll to top'));
     expect(scrollToTop).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ArticleCard/index.tsx
+++ b/src/components/ArticleCard/index.tsx
@@ -68,8 +68,12 @@ export default function ArticleCard({ article }: Props) {
             target="_blank"
             href={`/articles/${article.slug}`}
             skipLocaleHandling
+            aria-label={`Read article: ${article.title}`}
           >
-            <ExportOutlined className="text-base font-extrabold text-black dark:text-white" />
+            <ExportOutlined
+              aria-hidden
+              className="text-base font-extrabold text-black dark:text-white"
+            />
           </Link>
         </div>
       </div>

--- a/src/components/AsideNav/index.tsx
+++ b/src/components/AsideNav/index.tsx
@@ -106,6 +106,9 @@ export default function AsideNav({
       </button>
 
       <nav
+        aria-label={t('Table of contents', {
+          defaultValue: 'Table of contents',
+        })}
         style={{ width: panelWidth }}
         className={`glass-nav rounded-r-lg transition-all duration-300 ${
           open
@@ -141,6 +144,7 @@ export default function AsideNav({
                 >
                   <button
                     onClick={() => scrollTo(key)}
+                    aria-current={active === key ? 'location' : undefined}
                     style={
                       active === key
                         ? {

--- a/src/components/CertificateCard/index.tsx
+++ b/src/components/CertificateCard/index.tsx
@@ -47,8 +47,15 @@ export default function CertificateCard({ name, platform, url }: Props) {
       </div>
 
       <div className="ml-5 items-end justify-center font-bold no-underline hover:no-underline">
-        <Link target="_blank" href={url}>
-          <ExportOutlined className="text-base font-extrabold text-black dark:text-white" />
+        <Link
+          target="_blank"
+          href={url}
+          aria-label={`Open ${t(name)} certificate`}
+        >
+          <ExportOutlined
+            aria-hidden
+            className="text-base font-extrabold text-black dark:text-white"
+          />
         </Link>
       </div>
     </motion.div>

--- a/src/components/ContactForm/index.tsx
+++ b/src/components/ContactForm/index.tsx
@@ -124,7 +124,11 @@ export default function ContactForm() {
         />
       </div>
 
-      <div className="flex items-center gap-4">
+      <div
+        className="flex items-center gap-4"
+        role={status === 'error' ? 'alert' : 'status'}
+        aria-live={status === 'error' ? 'assertive' : 'polite'}
+      >
         <motion.button
           type="submit"
           disabled={status === 'sending'}

--- a/src/components/DarkModeToggle/index.tsx
+++ b/src/components/DarkModeToggle/index.tsx
@@ -12,6 +12,7 @@ export default function DarkModeToggle({ isDark, toggle }: Props) {
     <button
       onClick={toggle}
       aria-label="Toggle dark mode"
+      aria-pressed={isDark}
       className="glass-btn relative inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-full p-2 text-xl"
     >
       <AnimatePresence mode="wait" initial={false}>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -11,7 +11,7 @@ const Footer = () => {
     >
       <div className="flex items-center justify-center">
         <p className="mr-2">{t('Made with')}</p>
-        <HeartFilled className="text-red-700" />
+        <HeartFilled className="text-red-700" aria-hidden />
         <p className="ml-2">{t('by Lucas Morais')}</p>
       </div>
     </footer>

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -8,13 +8,15 @@ import Link from '../Link';
 
 interface FlagIconProps {
   countryCode: string;
+  'aria-hidden'?: boolean;
 }
 
-function FlagIcon({ countryCode = '' }: FlagIconProps) {
+function FlagIcon({ countryCode = '', ...rest }: FlagIconProps) {
   const clazz = `fi-${countryCode}`;
   return (
     <span
       className={`fi fis ${clazz} inline-block h-6 w-6 rounded-full text-2xl`}
+      {...rest}
     />
   );
 }
@@ -73,8 +75,9 @@ export default function LanguageSelector() {
                 id={LANGUAGE_SELECTOR_ID}
                 aria-haspopup="true"
                 aria-expanded={isOpen}
+                aria-label={selectedLanguage.name}
               >
-                <FlagIcon countryCode={selectedLanguage.key} />
+                <FlagIcon countryCode={selectedLanguage.key} aria-hidden />
               </button>
             </Tooltip>
           </div>
@@ -107,7 +110,7 @@ export default function LanguageSelector() {
                         }`}
                         role="menuitem"
                       >
-                        <FlagIcon countryCode={language.key} />
+                        <FlagIcon countryCode={language.key} aria-hidden />
                         <span className="ml-2 truncate">{language.name}</span>
                       </button>
                     </Link>

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -11,6 +11,7 @@ interface Props extends LinkProps {
   target?: string;
   className?: string;
   children?: React.ReactNode;
+  'aria-label'?: string;
 }
 
 const LinkComponent = ({

--- a/src/components/LoadingScreen/index.tsx
+++ b/src/components/LoadingScreen/index.tsx
@@ -10,6 +10,9 @@ type Props = {
 const LoadingScreen = ({ name }: Props) => {
   return (
     <motion.div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading"
       initial={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.5, ease: 'easeInOut' }}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -19,7 +19,10 @@ export default function Navbar({
   const { isDark, toggle } = useContext(DarkModeContext);
 
   return (
-    <nav className="glass-nav sticky top-0 z-50 p-4 px-6 no-underline md:px-16">
+    <nav
+      aria-label="Main navigation"
+      className="glass-nav sticky top-0 z-50 p-4 px-6 no-underline md:px-16"
+    >
       <div className="container mx-auto">
         <div className="flex items-center justify-between">
           <Link href="/" className={'text-primary hover:border-0'}>

--- a/src/components/ProjectCard/index.tsx
+++ b/src/components/ProjectCard/index.tsx
@@ -71,8 +71,15 @@ export default function ProjectCard({
         </div>
 
         <div className="ml-3 mt-1 flex shrink-0 items-center justify-center">
-          <Link target="_blank" href={url}>
-            <ExportOutlined className="text-base font-extrabold text-black dark:text-white" />
+          <Link
+            target="_blank"
+            href={url}
+            aria-label={`Open ${name} on GitHub`}
+          >
+            <ExportOutlined
+              aria-hidden
+              className="text-base font-extrabold text-black dark:text-white"
+            />
           </Link>
         </div>
       </div>

--- a/src/components/ReadingProgress/index.tsx
+++ b/src/components/ReadingProgress/index.tsx
@@ -10,6 +10,11 @@ export default function ReadingProgress({ progress }: Props) {
 
   return (
     <motion.div
+      role="progressbar"
+      aria-label="Reading progress"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(progress * 100)}
       style={{ scaleX: progress }}
       transition={
         prefersReducedMotion

--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -11,18 +11,20 @@ const ScrollToTopButton = ({ isVisible, scrollToTop }: Props) => {
   return (
     <AnimatePresence>
       {isVisible && (
-        <motion.div
+        <motion.button
+          type="button"
           initial={{ opacity: 0, scale: 0.5 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.5 }}
           transition={{ duration: 0.2 }}
           onClick={scrollToTop}
-          className="fixed bottom-5 right-5 cursor-pointer rounded-full text-white shadow-lg"
+          aria-label="Scroll to top"
+          className="fixed bottom-5 right-5 rounded-full text-white shadow-lg"
         >
           <div className="flex h-11 w-11 justify-center rounded-full bg-primary p-5 align-middle text-white hover:text-gray-400">
-            <ArrowUpOutlined />
+            <ArrowUpOutlined aria-hidden />
           </div>
-        </motion.div>
+        </motion.button>
       )}
     </AnimatePresence>
   );

--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -10,6 +10,7 @@ const Field = ({
   placeholder,
   type = 'text',
   multiline,
+  required,
 }: {
   label: string;
   value: string;
@@ -19,10 +20,12 @@ const Field = ({
   placeholder: string;
   type?: string;
   multiline?: boolean;
+  required?: boolean;
 }) => (
   <label className="block">
     <span className="mb-1.5 block font-mono text-[10.5px] uppercase tracking-widest text-slate-500">
       {label}
+      {required && <span aria-hidden> *</span>}
     </span>
     {multiline ? (
       <textarea
@@ -30,6 +33,7 @@ const Field = ({
         onChange={onChange}
         placeholder={placeholder}
         rows={4}
+        required={required}
         className="w-full rounded-lg px-3 py-2.5 text-[13.5px] text-slate-100 transition-colors focus:outline-none"
         style={{
           background: 'rgba(255,255,255,0.03)',
@@ -42,6 +46,7 @@ const Field = ({
         value={value}
         onChange={onChange}
         placeholder={placeholder}
+        required={required}
         className="w-full rounded-lg px-3 py-2.5 text-[13.5px] text-slate-100 transition-colors focus:outline-none"
         style={{
           background: 'rgba(255,255,255,0.03)',
@@ -210,6 +215,7 @@ export default function ContactSection({
                     value={form.name}
                     onChange={set('name')}
                     placeholder={t('contact.namePh')}
+                    required
                   />
                   <Field
                     label={t('contact.email')}
@@ -217,6 +223,7 @@ export default function ContactSection({
                     onChange={set('email')}
                     placeholder={t('contact.emailPh')}
                     type="email"
+                    required
                   />
                 </div>
                 <Field
@@ -231,6 +238,7 @@ export default function ContactSection({
                   onChange={set('message')}
                   placeholder={t('contact.messagePh')}
                   multiline
+                  required
                 />
                 <div className="flex items-center justify-between pt-2">
                   <span className="font-mono text-[11px] text-slate-500">
@@ -239,6 +247,7 @@ export default function ContactSection({
                   <button
                     type="submit"
                     disabled={sending}
+                    aria-live="polite"
                     className="rounded-lg px-5 py-2.5 text-[13px] font-medium transition-all"
                     style={{
                       background: btnBg,

--- a/src/components/portfolio/Nav.tsx
+++ b/src/components/portfolio/Nav.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { ACCENT } from './atoms';
 
@@ -46,6 +46,8 @@ interface Props {
 export default function Nav({ accent = ACCENT }: Props) {
   const { t } = useTranslation('common');
   const [open, setOpen] = useState(false);
+  const openButtonRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const links: [string, string][] = [
     [t('nav.about'), '#about'],
     [t('nav.architecture'), '#architecture'],
@@ -59,8 +61,17 @@ export default function Nav({ accent = ACCENT }: Props) {
   useEffect(() => {
     if (!open) return undefined;
     document.body.style.overflow = 'hidden';
+    closeButtonRef.current?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+
     return () => {
       document.body.style.overflow = '';
+      document.removeEventListener('keydown', onKeyDown);
+      openButtonRef.current?.focus();
     };
   }, [open]);
 
@@ -68,6 +79,7 @@ export default function Nav({ accent = ACCENT }: Props) {
     <>
       {/* Desktop nav */}
       <nav
+        aria-label="Primary"
         className="glass-nav fixed left-1/2 top-4 z-50 hidden -translate-x-1/2 items-center gap-1 rounded-full p-2 lg:flex"
         style={{ maxWidth: 'calc(100vw - 32px)' }}
       >
@@ -106,7 +118,10 @@ export default function Nav({ accent = ACCENT }: Props) {
       </nav>
 
       {/* Mobile top bar */}
-      <nav className="glass-nav fixed inset-x-3 top-3 z-50 flex items-center justify-between rounded-full p-2 lg:hidden">
+      <nav
+        aria-label="Primary"
+        className="glass-nav fixed inset-x-3 top-3 z-50 flex items-center justify-between rounded-full p-2 lg:hidden"
+      >
         <div className="flex items-center gap-2 py-1 pl-2">
           <span
             className="inline-block h-2 w-2 rounded-full"
@@ -117,9 +132,12 @@ export default function Nav({ accent = ACCENT }: Props) {
           </span>
         </div>
         <button
+          ref={openButtonRef}
           type="button"
           onClick={() => setOpen(true)}
           aria-label="Open menu"
+          aria-haspopup="dialog"
+          aria-expanded={open}
           className="flex h-9 w-9 items-center justify-center rounded-full"
           style={{
             background: 'var(--toggle-bg)',
@@ -158,7 +176,9 @@ export default function Nav({ accent = ACCENT }: Props) {
             className="glass-nav absolute inset-y-0 right-0 flex w-[82vw] max-w-sm flex-col"
             style={{ borderRadius: '16px 0 0 16px' }}
             onClick={(e) => e.stopPropagation()}
-            role="presentation"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Menu"
           >
             <div
               className="flex items-center justify-between border-b p-5"
@@ -166,6 +186,7 @@ export default function Nav({ accent = ACCENT }: Props) {
             >
               <span className="font-mono text-[13px] text-slate-200">menu</span>
               <button
+                ref={closeButtonRef}
                 type="button"
                 onClick={() => setOpen(false)}
                 aria-label="Close menu"

--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { useTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 
 import ArchitectureSection from '@/components/portfolio/Architecture';
@@ -25,6 +26,7 @@ import { getStaticPaths, makeStaticProps } from '@/utils/getStatic';
 import { GITHUB_REPO } from '@/utils/url';
 
 const Index = () => {
+  const { t } = useTranslation('common');
   const [languages, setLanguages] = useState<LanguageDatum[]>([]);
   const [projects, setProjects] = useState<ProjectDatum[]>([]);
   const [articles, setArticles] = useState<DevtoArticleIndex[]>([]);
@@ -115,6 +117,13 @@ const Index = () => {
         />
       </Head>
 
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
+      >
+        {t('a11y.skipToContent', { defaultValue: 'Skip to content' })}
+      </a>
+
       <div
         className="relative min-h-screen overflow-x-hidden"
         style={{ background: 'var(--bg-base)' }}
@@ -128,31 +137,33 @@ const Index = () => {
 
         <div className="relative" style={{ zIndex: 10 }}>
           <Nav accent={ACCENT} />
-          <Hero accent={ACCENT} accentB={ACCENT_B} username={username} />
-          <ArchitectureSection accent={ACCENT} accentB={ACCENT_B} />
-          <StackSection accent={ACCENT} accentB={ACCENT_B} />
-          <LanguagesSection
-            data={languages}
-            accent={ACCENT}
-            accentB={ACCENT_B}
-          />
-          <ProjectsSection
-            projects={projects}
-            accent={ACCENT}
-            accentB={ACCENT_B}
-            username={username}
-          />
-          <ArticlesSection
-            articles={articles}
-            accent={ACCENT}
-            accentB={ACCENT_B}
-          />
-          <ContactSection
-            accent={ACCENT}
-            accentB={ACCENT_B}
-            email={email}
-            username={username}
-          />
+          <main id="main-content">
+            <Hero accent={ACCENT} accentB={ACCENT_B} username={username} />
+            <ArchitectureSection accent={ACCENT} accentB={ACCENT_B} />
+            <StackSection accent={ACCENT} accentB={ACCENT_B} />
+            <LanguagesSection
+              data={languages}
+              accent={ACCENT}
+              accentB={ACCENT_B}
+            />
+            <ProjectsSection
+              projects={projects}
+              accent={ACCENT}
+              accentB={ACCENT_B}
+              username={username}
+            />
+            <ArticlesSection
+              articles={articles}
+              accent={ACCENT}
+              accentB={ACCENT_B}
+            />
+            <ContactSection
+              accent={ACCENT}
+              accentB={ACCENT_B}
+              email={email}
+              username={username}
+            />
+          </main>
         </div>
       </div>
     </>

--- a/src/pages/articles/[slug].tsx
+++ b/src/pages/articles/[slug].tsx
@@ -421,6 +421,12 @@ export default function ArticlePage() {
   const shell = (children: React.ReactNode, meta?: React.ReactNode) => (
     <>
       {meta}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
+      >
+        {t('a11y.skipToContent', { defaultValue: 'Skip to content' })}
+      </a>
       <div
         className="relative min-h-screen overflow-x-hidden"
         style={{ background: 'var(--bg-base)' }}
@@ -433,7 +439,7 @@ export default function ArticlePage() {
         />
         <div className="relative" style={{ zIndex: 10 }}>
           <ArticleNav accent={ACCENT} />
-          {children}
+          <main id="main-content">{children}</main>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- Add accessible names to icon-only controls (project/article/certificate export links, language selector trigger) and hide purely decorative icons from assistive tech with `aria-hidden`
- Convert `ScrollToTopButton` from a clickable `div` into a real, keyboard-operable `<button>`
- Add dialog semantics (`role="dialog"`, `aria-modal`), Escape-to-close, and focus management (focus moves to the close button on open, returns to the trigger on close) to the mobile nav drawer
- Add `aria-live` status/alert regions for async submit feedback in both contact forms, and mark required fields with `required` + a visible/semantic indicator
- Add a `main#main-content` landmark and a "Skip to content" link on the homepage and article pages, plus `aria-label`s distinguishing nav landmarks
- Add `role="progressbar"` to `ReadingProgress`, `role="status"` to `LoadingScreen`, `aria-current` to the active table-of-contents item, and `aria-pressed` to the dark mode toggle

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 27/27 suites, 104/104 tests pass (updated `ScrollToTopButton.test.tsx` to query by its new accessible name instead of icon role)
- [x] Manually verified in a headless browser: skip link + `main` landmark render on the homepage, mobile nav drawer opens as a dialog with correct focus management and closes on Escape with focus returned to the trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_