### PR TITLE
Add mobile nav to the article reader page

### DIFF
--- a/src/pages/articles/[slug].tsx
+++ b/src/pages/articles/[slug].tsx
@@ -237,69 +237,223 @@ const TocAside = ({
 
 const ArticleNav = ({ accent }: { accent: string }) => {
   const { t } = useTranslation('common');
+  const [open, setOpen] = useState(false);
   const items: [string, string][] = [
     [t('nav.about', { defaultValue: 'About' }), '/#about'],
     [t('nav.architecture', { defaultValue: 'Architecture' }), '/#architecture'],
     [t('nav.projects', { defaultValue: 'Projects' }), '/#projects'],
     [t('nav.writing', { defaultValue: 'Writing' }), '/#writing'],
   ];
+
+  useEffect(() => {
+    if (!open) return undefined;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
   return (
-    <nav
-      className="glass-nav fixed left-1/2 top-4 z-50 hidden -translate-x-1/2 items-center gap-1 rounded-full p-2 lg:flex"
-      style={{ maxWidth: 'calc(100vw - 32px)' }}
-    >
-      {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
-      <a
-        href="/"
-        className="flex items-center gap-2 py-1 pl-3 pr-2 hover:opacity-90"
+    <>
+      {/* Desktop nav */}
+      <nav
+        className="glass-nav fixed left-1/2 top-4 z-50 hidden -translate-x-1/2 items-center gap-1 rounded-full p-2 lg:flex"
+        style={{ maxWidth: 'calc(100vw - 32px)' }}
       >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke={accent}
-          strokeWidth="2"
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
+        <a
+          href="/"
+          className="flex items-center gap-2 py-1 pl-3 pr-2 hover:opacity-90"
         >
-          <path d="m15 18-6-6 6-6" />
-        </svg>
-        <span
-          className="inline-block h-2 w-2 rounded-full"
-          style={{ background: accent, boxShadow: `0 0 12px ${accent}` }}
-        />
-        <span className="font-mono text-[13px] tracking-tight text-slate-200">
-          lucasheartcliff
-        </span>
-      </a>
-      <div className="ml-1 flex items-center gap-0.5">
-        {items.map(([label, href]) => (
-          <a
-            key={label}
-            href={href}
-            className="rounded-full px-3 py-1.5 text-[12.5px] text-slate-300 transition-colors hover:text-white"
-            style={
-              label === t('nav.writing', { defaultValue: 'Writing' })
-                ? { color: accent }
-                : {}
-            }
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={accent}
+            strokeWidth="2"
           >
-            {label}
-          </a>
-        ))}
-      </div>
-      {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
-      <a
-        href="/#contact"
-        className="ml-1 rounded-full px-3.5 py-1.5 text-[12.5px] font-medium transition-all"
-        style={{
-          background: `linear-gradient(135deg, ${accent}, ${accent}aa)`,
-          color: '#0b1020',
-          boxShadow: `0 4px 24px ${accent}44`,
-        }}
-      >
-        {t('cta.hireMe', { defaultValue: 'Hire me' })}
-      </a>
-    </nav>
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ background: accent, boxShadow: `0 0 12px ${accent}` }}
+          />
+          <span className="font-mono text-[13px] tracking-tight text-slate-200">
+            lucasheartcliff
+          </span>
+        </a>
+        <div className="ml-1 flex items-center gap-0.5">
+          {items.map(([label, href]) => (
+            <a
+              key={label}
+              href={href}
+              className="rounded-full px-3 py-1.5 text-[12.5px] text-slate-300 transition-colors hover:text-white"
+              style={
+                label === t('nav.writing', { defaultValue: 'Writing' })
+                  ? { color: accent }
+                  : {}
+              }
+            >
+              {label}
+            </a>
+          ))}
+        </div>
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
+        <a
+          href="/#contact"
+          className="ml-1 rounded-full px-3.5 py-1.5 text-[12.5px] font-medium transition-all"
+          style={{
+            background: `linear-gradient(135deg, ${accent}, ${accent}aa)`,
+            color: '#0b1020',
+            boxShadow: `0 4px 24px ${accent}44`,
+          }}
+        >
+          {t('cta.hireMe', { defaultValue: 'Hire me' })}
+        </a>
+      </nav>
+
+      {/* Mobile top bar */}
+      <nav className="glass-nav fixed inset-x-3 top-3 z-50 flex items-center justify-between rounded-full p-2 lg:hidden">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
+        <a
+          href="/"
+          className="flex items-center gap-2 py-1 pl-2 hover:opacity-90"
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={accent}
+            strokeWidth="2"
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ background: accent, boxShadow: `0 0 10px ${accent}` }}
+          />
+          <span className="font-mono text-[12.5px] tracking-tight text-slate-200">
+            lucasheartcliff
+          </span>
+        </a>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Open menu"
+          className="flex h-9 w-9 items-center justify-center rounded-full"
+          style={{
+            background: 'var(--toggle-bg)',
+            border: '1px solid var(--toggle-border)',
+            color: accent,
+          }}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M4 7h16M4 12h16M4 17h16" />
+          </svg>
+        </button>
+      </nav>
+
+      {/* Mobile drawer */}
+      {open && (
+        <div
+          className="fixed inset-0 z-[60] lg:hidden"
+          onClick={() => setOpen(false)}
+          role="presentation"
+        >
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'rgba(0,0,0,0.5)',
+              backdropFilter: 'blur(8px)',
+            }}
+          />
+          <div
+            className="glass-nav absolute inset-y-0 right-0 flex w-[82vw] max-w-sm flex-col"
+            style={{ borderRadius: '16px 0 0 16px' }}
+            onClick={(e) => e.stopPropagation()}
+            role="presentation"
+          >
+            <div
+              className="flex items-center justify-between border-b p-5"
+              style={{ borderColor: 'var(--hairline)' }}
+            >
+              <span className="font-mono text-[13px] text-slate-200">menu</span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close menu"
+                className="flex h-9 w-9 items-center justify-center rounded-full"
+                style={{
+                  background: 'var(--toggle-bg)',
+                  border: '1px solid var(--toggle-border)',
+                  color: 'var(--text-mute)',
+                }}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="M6 6l12 12M18 6L6 18" />
+                </svg>
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-5">
+              <div className="flex flex-col gap-1">
+                {items.map(([label, href], i) => (
+                  <a
+                    key={label}
+                    href={href}
+                    onClick={() => setOpen(false)}
+                    className="rounded-lg p-3 text-[15px] text-slate-200 transition-colors"
+                    style={{
+                      background: i === 0 ? 'var(--chip-bg)' : 'transparent',
+                    }}
+                  >
+                    <span
+                      className="mr-3 font-mono text-[10px]"
+                      style={{ color: accent }}
+                    >
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    {label}
+                  </a>
+                ))}
+              </div>
+            </div>
+            <div
+              className="flex items-center border-t p-5"
+              style={{ borderColor: 'var(--hairline)' }}
+            >
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- full reload reloads i18n */}
+              <a
+                href="/#contact"
+                onClick={() => setOpen(false)}
+                className="w-full rounded-full px-4 py-2 text-center text-[12.5px] font-medium"
+                style={{
+                  background: `linear-gradient(135deg, ${accent}, ${accent}aa)`,
+                  color: '#0b1020',
+                }}
+              >
+                {t('cta.hireMe', { defaultValue: 'Hire me' })}
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- `ArticleNav` (in `pages/articles/[slug].tsx`) was `hidden lg:flex` with no mobile counterpart, so visitors reading an article on a phone had no site navigation beyond a small "back to portfolio" link in the header
- Adds a mobile top bar + right-side drawer, mirroring the pattern already used by the homepage's `Nav` component: hamburger button → drawer with the same links (About/Architecture/Projects/Writing) and "Hire me" CTA as the desktop nav, body scroll locked while open
- Desktop nav is unchanged, just wrapped in a fragment alongside the new mobile markup

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 27/27 suites, 104/104 tests pass
- [x] Manually verified in a headless browser at a 375px viewport: desktop nav is hidden, mobile hamburger is visible and clickable, drawer opens with all nav items + CTA visible, closes via the close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_