### PR TITLE
Surface errors on failed homepage data fetches

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -198,18 +198,21 @@
     "years": "years",
     "summary": "≈ {y} years of keyboard time across {n} languages.",
     "thisWeek": "This week",
-    "byLang": "BY LANG"
+    "byLang": "BY LANG",
+    "error": "Couldn't load language stats right now."
   },
   "proj": {
     "label": "Featured Projects",
     "title": "Open source & experiments.",
     "allRepos": "All repos on GitHub →",
-    "pinned": "★ PINNED"
+    "pinned": "★ PINNED",
+    "error": "Couldn't load projects right now."
   },
   "writing": {
     "label": "Writing",
     "title": "Notes & deep dives.",
-    "all": "All articles →"
+    "all": "All articles →",
+    "error": "Couldn't load articles right now."
   },
   "contact": {
     "label": "Contact",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -198,18 +198,21 @@
     "years": "anos",
     "summary": "≈ {y} anos de tempo de teclado em {n} linguagens.",
     "thisWeek": "Esta semana",
-    "byLang": "POR LING"
+    "byLang": "POR LING",
+    "error": "Não foi possível carregar as estatísticas de linguagens agora."
   },
   "proj": {
     "label": "Projetos em Destaque",
     "title": "Open source & experimentos.",
     "allRepos": "Todos os repos no GitHub →",
-    "pinned": "★ FIXADO"
+    "pinned": "★ FIXADO",
+    "error": "Não foi possível carregar os projetos agora."
   },
   "writing": {
     "label": "Artigos",
     "title": "Notas & aprofundamentos.",
-    "all": "Todos os artigos →"
+    "all": "Todos os artigos →",
+    "error": "Não foi possível carregar os artigos agora."
   },
   "contact": {
     "label": "Contato",

--- a/src/components/portfolio/Articles.tsx
+++ b/src/components/portfolio/Articles.tsx
@@ -69,19 +69,21 @@ const ArticleCard = ({
 
 interface Props {
   articles: DevtoArticleIndex[];
+  error?: boolean;
   accent?: string;
   accentB?: string;
 }
 
 export default function ArticlesSection({
   articles,
+  error = false,
   accent = ACCENT,
   accentB = ACCENT_B,
 }: Props) {
   const { t } = useTranslation('common');
   const router = useRouter();
   const locale = (router.query.locale as string) || 'en';
-  if (!articles.length) return null;
+  if (!articles.length && !error) return null;
   return (
     <section id="writing" className="relative py-20 sm:py-28">
       <div className="mx-auto max-w-6xl px-5 sm:px-6">
@@ -96,18 +98,26 @@ export default function ArticlesSection({
           </div>
         </Reveal>
 
-        <div className="grid gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
-          {articles.slice(0, 6).map((article, i) => (
-            <Reveal key={article.id} delay={100 + i * 60}>
-              <ArticleCard
-                article={article}
-                accent={accent}
-                accentB={accentB}
-                locale={locale}
-              />
-            </Reveal>
-          ))}
-        </div>
+        {error ? (
+          <Glass className="p-6 text-center text-[13px] text-slate-400">
+            {t('writing.error', {
+              defaultValue: "Couldn't load articles right now.",
+            })}
+          </Glass>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
+            {articles.slice(0, 6).map((article, i) => (
+              <Reveal key={article.id} delay={100 + i * 60}>
+                <ArticleCard
+                  article={article}
+                  accent={accent}
+                  accentB={accentB}
+                  locale={locale}
+                />
+              </Reveal>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/components/portfolio/Languages.tsx
+++ b/src/components/portfolio/Languages.tsx
@@ -130,11 +130,16 @@ const DonutChart = ({
 
 interface Props {
   data: LanguageDatum[];
+  error?: boolean;
   accent?: string;
   accentB?: string;
 }
 
-export default function LanguagesSection({ data, accent = ACCENT }: Props) {
+export default function LanguagesSection({
+  data,
+  error = false,
+  accent = ACCENT,
+}: Props) {
   const { t } = useTranslation('common');
   const ref = useRef<HTMLDivElement>(null);
   const [animate, setAnimate] = useState(false);
@@ -158,7 +163,29 @@ export default function LanguagesSection({ data, accent = ACCENT }: Props) {
     return () => io.disconnect();
   }, [data.length]);
 
-  if (!data.length) return null;
+  if (!data.length && !error) return null;
+
+  if (error) {
+    return (
+      <section id="languages" className="relative py-20 sm:py-28">
+        <div className="mx-auto max-w-6xl px-5 sm:px-6">
+          <Reveal>
+            <SectionLabel num="03" label={t('lang.label')} accent={accent} />
+          </Reveal>
+          <Reveal delay={80}>
+            <h2 className="mb-12 max-w-xl font-display text-3xl tracking-[-0.02em] text-slate-100 sm:text-5xl">
+              {t('lang.title')}
+            </h2>
+          </Reveal>
+          <Glass className="p-6 text-center text-[13px] text-slate-400">
+            {t('lang.error', {
+              defaultValue: "Couldn't load language stats right now.",
+            })}
+          </Glass>
+        </div>
+      </section>
+    );
+  }
 
   const max = Math.max(...data.map((l) => l.hours));
   const total = data.reduce((s, l) => s + l.hours, 0);

--- a/src/components/portfolio/Projects.tsx
+++ b/src/components/portfolio/Projects.tsx
@@ -114,6 +114,7 @@ const ProjectCard = ({ p, accent }: { p: ProjectDatum; accent: string }) => {
 
 interface Props {
   projects: ProjectDatum[];
+  error?: boolean;
   accent?: string;
   accentB?: string;
   username?: string;
@@ -121,11 +122,12 @@ interface Props {
 
 export default function ProjectsSection({
   projects,
+  error = false,
   accent = ACCENT,
   username = 'lucasheartcliff',
 }: Props) {
   const { t } = useTranslation('common');
-  if (!projects.length) return null;
+  if (!projects.length && !error) return null;
   return (
     <section id="projects" className="relative py-20 sm:py-28">
       <div className="mx-auto max-w-6xl px-5 sm:px-6">
@@ -148,13 +150,21 @@ export default function ProjectsSection({
           </div>
         </Reveal>
 
-        <div className="grid gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
-          {projects.map((p, i) => (
-            <Reveal key={p.name} delay={100 + i * 60}>
-              <ProjectCard p={p} accent={accent} />
-            </Reveal>
-          ))}
-        </div>
+        {error ? (
+          <Glass className="p-6 text-center text-[13px] text-slate-400">
+            {t('proj.error', {
+              defaultValue: "Couldn't load projects right now.",
+            })}
+          </Glass>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3">
+            {projects.map((p, i) => (
+              <Reveal key={p.name} delay={100 + i * 60}>
+                <ProjectCard p={p} accent={accent} />
+              </Reveal>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -24,17 +24,25 @@ import {
 import { getStaticPaths, makeStaticProps } from '@/utils/getStatic';
 import { GITHUB_REPO } from '@/utils/url';
 
+function fetchJson(url: string) {
+  return fetch(url).then((res) => {
+    if (!res.ok) throw new Error(`Request to ${url} failed: ${res.status}`);
+    return res.json();
+  });
+}
+
 const Index = () => {
   const [languages, setLanguages] = useState<LanguageDatum[]>([]);
   const [projects, setProjects] = useState<ProjectDatum[]>([]);
   const [articles, setArticles] = useState<DevtoArticleIndex[]>([]);
+  const [articlesError, setArticlesError] = useState(false);
+  const [dataError, setDataError] = useState(false);
 
   const { firstName, lastName, username, email } = profile as any;
   const name = `${firstName} ${lastName}`.trim();
 
   useEffect(() => {
-    fetch('/api/articles')
-      .then((res) => (res.ok ? res.json() : []))
+    fetchJson('/api/articles')
       .then((fetched: DevtoArticleIndex[]) =>
         setArticles(
           [...fetched].sort(
@@ -44,12 +52,12 @@ const Index = () => {
           )
         )
       )
-      .catch(() => {});
+      .catch(() => setArticlesError(true));
 
     Promise.all([
-      fetch('/api/github/repos').then((r) => (r.ok ? r.json() : [])),
-      fetch('/api/wakatime/coding-time').then((r) => (r.ok ? r.json() : {})),
-      fetch('/api/wakatime/languages').then((r) => (r.ok ? r.json() : {})),
+      fetchJson('/api/github/repos'),
+      fetchJson('/api/wakatime/coding-time'),
+      fetchJson('/api/wakatime/languages'),
     ])
       .then(([repos, coding, langs]: any[]) => {
         setProjects(
@@ -88,7 +96,7 @@ const Index = () => {
         langData.sort((a, b) => b.hours - a.hours);
         setLanguages(langData);
       })
-      .catch(() => {});
+      .catch(() => setDataError(true));
   }, [username]);
 
   return (
@@ -133,17 +141,20 @@ const Index = () => {
           <StackSection accent={ACCENT} accentB={ACCENT_B} />
           <LanguagesSection
             data={languages}
+            error={dataError}
             accent={ACCENT}
             accentB={ACCENT_B}
           />
           <ProjectsSection
             projects={projects}
+            error={dataError}
             accent={ACCENT}
             accentB={ACCENT_B}
             username={username}
           />
           <ArticlesSection
             articles={articles}
+            error={articlesError}
             accent={ACCENT}
             accentB={ACCENT_B}
           />


### PR DESCRIPTION
## Summary
Projects, Languages, and Articles all silently rendered nothing when their backing fetch failed — `.catch(() => {})` plus treating any non-ok response as an empty array meant a downed GitHub/WakaTime/Dev.to proxy looked identical to "genuinely no data" to a visitor, with the section and its nav anchor just vanishing.

- Adds a `fetchJson()` helper that throws on a non-ok response, so HTTP errors and network failures both funnel through the same `.catch()` instead of only network failures being catchable
- Tracks `articlesError` / `dataError` state on the homepage and passes an `error` prop down to `ArticlesSection`, `ProjectsSection`, and `LanguagesSection`
- Each section now renders its heading plus a small inline message on error, instead of disappearing entirely; the existing "hide when genuinely empty and not an error" behavior is unchanged
- Adds `proj.error` / `writing.error` / `lang.error` translation keys (en + pt)

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 27/27 suites, 104/104 tests pass
- [x] Manually verified against this environment's own API proxies, which happen to be in exactly the failure/success split this PR is about: GitHub (401) and WakaTime (400) proxies genuinely fail here, and Projects/Languages now show their error message instead of vanishing; the Dev.to proxy genuinely succeeds with an empty list here, and Articles correctly stays hidden rather than showing a false error

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_