### PR TITLE
Lazy-load article images (next/image isn't a safe fit here)

### DIFF
--- a/src/components/ImageLightbox/index.tsx
+++ b/src/components/ImageLightbox/index.tsx
@@ -58,6 +58,7 @@ function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       <img
         src={src}
         alt={alt || ''}
+        decoding="async"
         onClick={(e) => {
           e.stopPropagation();
           setZoomed((z) => !z);
@@ -93,9 +94,18 @@ export function ClickableImage({ src, alt, className }: ClickableImageProps) {
 
   return (
     <>
+      {/*
+        Plain <img>, not next/image: this renders arbitrary external URLs
+        from Dev.to article markdown (and the article cover image), so
+        there's no fixed set of remote hosts to allowlist in next.config.js,
+        and no known intrinsic size to satisfy next/image's width/height
+        requirement. Native lazy loading covers the real win here.
+      */}
       <img
         src={src}
         alt={alt || ''}
+        loading="lazy"
+        decoding="async"
         className={className}
         onClick={() => setOpen(true)}
         role="button"


### PR DESCRIPTION
## Summary
This was scoped as "swap raw `<img>` for `next/image`," but after auditing the actual live usage, that swap isn't the right call here — this PR does the real, safe version of the improvement instead. Details below.

**What's actually live**: only two `<img>` tags remain in the app after the dead-code cleanup (both in `ImageLightbox`), rendering Dev.to article body images (from markdown) and the article cover image.

**Why not `next/image`**: both render an arbitrary external URL — whatever the article author linked to in their markdown, or Dev.to's cover image field. `next/image` requires either a fixed allowlist of remote hostnames in `next.config.js` (impossible to enumerate for arbitrary author content — an unconfigured hostname throws at runtime) or `unoptimized: true`, and either way it needs a known `width`/`height` (or a sized `fill` parent), which we don't have for arbitrary remote images. Forcing it here would trade a real bug (broken images for unconfigured hosts) for a nonexistent optimization win.

**What this PR does instead**: adds native `loading="lazy"` + `decoding="async"` to the inline `ClickableImage` (article body / cover image) — the actual, safe portion of the win, no config needed. The lightbox's full-size zoom image keeps eager loading since it only mounts on a direct click and should render immediately, not be deprioritized.

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 27/27 suites, 104/104 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_