### PR TITLE
Add test coverage for the live portfolio components and pages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,13 @@ const createJestConfig = nextJest({
 
 const customJestConfig = {
   moduleNameMapper: {
+    // More specific alias first: @/public/* must not fall through to the
+    // general @/* rule below, or it resolves into src/public instead of
+    // the real public/ directory.
+    '^@/public/(.*)$': '<rootDir>/public/$1',
+
     // Handle module aliases (this will be automatically configured for you soon)
     '^@/(.*)$': '<rootDir>/src/$1',
-
-    '^@/public/(.*)$': '<rootDir>/public/$1',
 
     // @vercel/analytics ships ESM that jest doesn't transform; stub it.
     '^@vercel/analytics/next$': '<rootDir>/__mocks__/vercelAnalytics.tsx',

--- a/src/__tests__/pages/articles-slug.test.tsx
+++ b/src/__tests__/pages/articles-slug.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ArticlePage from '@/pages/articles/[slug]';
+import type { DevtoArticleFull } from '@/services/devto';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { slug: 'understanding-backpressure', locale: 'en' },
+    basePath: '',
+  }),
+}));
+
+// react-markdown ships ESM-only, which Jest's default CJS transform can't
+// parse. Its own rendering is third-party, well-tested code; what these
+// tests need to verify is that the page wires the right data into it, so a
+// plain-text stand-in is enough.
+jest.mock('react-markdown', () => {
+  return function MockReactMarkdown({ children }: { children: string }) {
+    return <div>{children}</div>;
+  };
+});
+
+const fullArticle: DevtoArticleFull = {
+  type_of: 'article',
+  id: 1,
+  title: 'Understanding Backpressure',
+  description: 'A deep dive into flow control',
+  slug: 'understanding-backpressure',
+  path: '/understanding-backpressure',
+  url: 'https://dev.to/understanding-backpressure',
+  canonical_url: 'https://dev.to/understanding-backpressure',
+  cover_image: null,
+  social_image: null,
+  readable_publish_date: 'Jan 1',
+  published_at: '2025-01-15T10:00:00Z',
+  published_timestamp: '2025-01-15T10:00:00Z',
+  created_at: '2025-01-15T10:00:00Z',
+  edited_at: null,
+  crossposted_at: null,
+  last_comment_at: '2025-01-15T10:00:00Z',
+  reading_time_minutes: 5,
+  tag_list: 'systems',
+  tags: ['systems'],
+  comments_count: 0,
+  positive_reactions_count: 0,
+  public_reactions_count: 0,
+  body_html: '<p>Body</p>',
+  body_markdown: '# Heading\n\nSome body content.',
+  user: {
+    name: 'Lucas Morais',
+    username: 'lucasheartcliff',
+    twitter_username: null,
+    github_username: null,
+    website_url: null,
+    profile_image: '',
+    profile_image_90: '',
+  },
+};
+
+function mockFetchWith(articleResponse: Response) {
+  global.fetch = jest.fn((url: string) => {
+    if (url.startsWith('/api/articles/understanding-backpressure')) {
+      return Promise.resolve(articleResponse);
+    }
+    return Promise.resolve({ ok: true, json: async () => [] } as Response);
+  }) as unknown as typeof fetch;
+}
+
+describe('ArticlePage', () => {
+  it('renders the article title and body once loaded', async () => {
+    mockFetchWith({ ok: true, json: async () => fullArticle } as Response);
+    render(<ArticlePage />);
+    expect(
+      await screen.findByText('Understanding Backpressure')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Some body content/)).toBeInTheDocument();
+  });
+
+  it('shows a not-found state when the article fails to load', async () => {
+    mockFetchWith({ ok: false, json: async () => null } as Response);
+    render(<ArticlePage />);
+    expect(await screen.findByText('Article not found.')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/pages/articles-slug.test.tsx
+++ b/src/__tests__/pages/articles-slug.test.tsx
@@ -67,7 +67,7 @@ const fullArticle: DevtoArticleFull = {
 
 function mockFetchWith(articleResponse: Response) {
   global.fetch = jest.fn((url: string) => {
-    if (url.startsWith('/api/articles/understanding-backpressure')) {
+    if (url === '/api/articles/understanding-backpressure') {
       return Promise.resolve(articleResponse);
     }
     return Promise.resolve({ ok: true, json: async () => [] } as Response);

--- a/src/__tests__/pages/index.test.tsx
+++ b/src/__tests__/pages/index.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import Index from '@/pages/[locale]/index';
+
+const translations: Record<string, string> = {
+  'hero.available': 'Available for new roles',
+  'hero.line1': 'Line one',
+  'hero.line2': 'Line two',
+  'hero.line3': 'Line three',
+  'hero.viewProjects': 'View Projects',
+  'hero.downloadCV': 'Download CV',
+  'hero.scroll': 'Scroll',
+  'hero.bio': 'Building systems.',
+  'role.0': 'Backend Engineer',
+  'role.1': 'Platform Engineer',
+  'role.2': 'Systems Architect',
+  'role.3': 'Problem Solver',
+};
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => translations[key] ?? key }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { locale: 'en' }, basePath: '' }),
+}));
+
+describe('Index page', () => {
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => [] });
+  });
+
+  it('renders the hero headline and the primary nav', () => {
+    render(<Index />);
+    expect(screen.getByText('Line one')).toBeInTheDocument();
+    expect(screen.getAllByText('lucasheartcliff').length).toBeGreaterThan(0);
+  });
+
+  it('renders every top-level section landmark', () => {
+    render(<Index />);
+    ['about', 'architecture', 'stack', 'contact'].forEach((id) => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.getElementById(id)).toBeInTheDocument();
+    });
+  });
+
+  it('fetches articles, GitHub repos, and WakaTime stats on mount', () => {
+    render(<Index />);
+    const urls = (global.fetch as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        '/api/articles',
+        '/api/github/repos',
+        '/api/wakatime/coding-time',
+        '/api/wakatime/languages',
+      ])
+    );
+  });
+});

--- a/src/__tests__/portfolio/Architecture.test.tsx
+++ b/src/__tests__/portfolio/Architecture.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ArchitectureSection from '@/components/portfolio/Architecture';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('ArchitectureSection', () => {
+  it('renders the section heading', () => {
+    render(<ArchitectureSection />);
+    expect(screen.getByText('arch.title1')).toBeInTheDocument();
+    expect(screen.getByText('arch.title2')).toBeInTheDocument();
+  });
+
+  it('renders the tech tags for each architecture card', () => {
+    render(<ArchitectureSection />);
+    expect(screen.getByText('Kafka')).toBeInTheDocument();
+    expect(screen.getByText('DDD')).toBeInTheDocument();
+    expect(screen.getByText('OAuth2')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/portfolio/Articles.test.tsx
+++ b/src/__tests__/portfolio/Articles.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ArticlesSection from '@/components/portfolio/Articles';
+import type { DevtoArticleIndex } from '@/services/devto';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { locale: 'en' } }),
+}));
+
+const baseArticle: DevtoArticleIndex = {
+  type_of: 'article',
+  id: 1,
+  title: 'Understanding Backpressure',
+  description: 'A deep dive',
+  slug: 'understanding-backpressure',
+  path: '/understanding-backpressure',
+  url: 'https://dev.to/understanding-backpressure',
+  canonical_url: 'https://dev.to/understanding-backpressure',
+  cover_image: null,
+  social_image: null,
+  readable_publish_date: 'Jan 1',
+  published_at: '2025-01-15T10:00:00Z',
+  published_timestamp: '2025-01-15T10:00:00Z',
+  created_at: '2025-01-15T10:00:00Z',
+  edited_at: null,
+  crossposted_at: null,
+  last_comment_at: '2025-01-15T10:00:00Z',
+  reading_time_minutes: 5,
+  tag_list: ['systems'],
+  tags: 'systems',
+  comments_count: 0,
+  positive_reactions_count: 0,
+  public_reactions_count: 0,
+  user: {
+    name: 'Lucas Morais',
+    username: 'lucasheartcliff',
+    twitter_username: null,
+    github_username: null,
+    website_url: null,
+    profile_image: '',
+    profile_image_90: '',
+  },
+};
+
+describe('ArticlesSection', () => {
+  it('renders nothing with no articles', () => {
+    const { container } = render(<ArticlesSection articles={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders an article card linking to the article page', () => {
+    render(<ArticlesSection articles={[baseArticle]} />);
+    expect(screen.getByText('Understanding Backpressure')).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    const link = screen.getByText('Understanding Backpressure').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      '/articles/understanding-backpressure'
+    );
+  });
+
+  it('shows at most 6 articles', () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({
+      ...baseArticle,
+      id: i,
+      slug: `article-${i}`,
+      title: `Article ${i}`,
+    }));
+    render(<ArticlesSection articles={many} />);
+    expect(screen.getAllByText(/^Article \d$/)).toHaveLength(6);
+  });
+});

--- a/src/__tests__/portfolio/Contact.test.tsx
+++ b/src/__tests__/portfolio/Contact.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import ContactSection from '@/components/portfolio/Contact';
+
+const translations: Record<string, string> = {
+  'contact.label': 'Contact',
+  'contact.title1': "Let's build",
+  'contact.title2': 'something solid.',
+  'contact.body': 'Have a project in mind?',
+  'contact.name': 'Name',
+  'contact.namePh': 'Your name',
+  'contact.email': 'Email',
+  'contact.emailPh': 'you@example.com',
+  'contact.subject': 'Subject',
+  'contact.subjectPh': 'What is this about?',
+  'contact.message': 'Message',
+  'contact.messagePh': 'Your message',
+  'contact.replies': 'I usually reply within a day',
+  'contact.send': 'Send',
+  'contact.sending': 'Sending…',
+  'contact.sent': 'Sent!',
+  'contact.error': 'Something went wrong',
+  'contact.row.email': 'Email',
+  'contact.row.github': 'GitHub',
+  'contact.row.linkedin': 'LinkedIn',
+  'contact.row.location': 'Location',
+  'contact.row.locationValue': 'Brazil',
+  'contact.currentStatus': 'Current status',
+  'contact.openTo': 'Open to work',
+  'footer.built': 'built with care',
+};
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => translations[key] ?? key }),
+}));
+
+describe('ContactSection', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  });
+
+  it('renders all form fields', () => {
+    render(<ContactSection />);
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Subject')).toBeInTheDocument();
+    expect(screen.getByLabelText('Message')).toBeInTheDocument();
+  });
+
+  it('submits the form to the contact API and shows a success state', async () => {
+    render(<ContactSection />);
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Ada Lovelace' },
+    });
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'ada@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Message'), {
+      target: { value: 'Hi there' },
+    });
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/contact/',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual(
+      expect.objectContaining({
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+      })
+    );
+    expect(await screen.findByText('Sent!')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the request fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    render(<ContactSection />);
+    fireEvent.click(screen.getByText('Send'));
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/portfolio/Contact.test.tsx
+++ b/src/__tests__/portfolio/Contact.test.tsx
@@ -38,6 +38,16 @@ jest.mock('next-i18next', () => ({
 describe('ContactSection', () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    // ContactSection resets its status back to 'idle' via a 3.5s setTimeout
+    // after every submit. Fake timers (auto-advancing, so waitFor/findByText
+    // still work without manual jest.advanceTimersByTime calls) keep that
+    // timer from outliving the test and firing a state update on an
+    // unmounted component.
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('renders all form fields', () => {

--- a/src/__tests__/portfolio/Hero.test.tsx
+++ b/src/__tests__/portfolio/Hero.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import Hero from '@/components/portfolio/Hero';
+
+const translations: Record<string, string> = {
+  'hero.available': 'Available for new roles',
+  'hero.line1': 'Line one',
+  'hero.line2': 'Line two',
+  'hero.line3': 'Line three',
+  'hero.viewProjects': 'View Projects',
+  'hero.downloadCV': 'Download CV',
+  'hero.scroll': 'Scroll',
+  'hero.bio': 'Building systems.',
+  'role.0': 'Backend Engineer',
+  'role.1': 'Platform Engineer',
+  'role.2': 'Systems Architect',
+  'role.3': 'Problem Solver',
+};
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => translations[key] ?? key }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ basePath: '' }),
+}));
+
+describe('Hero', () => {
+  it('renders the headline lines', () => {
+    render(<Hero username="octocat" />);
+    expect(screen.getByText('Line one')).toBeInTheDocument();
+    expect(screen.getByText('Line two')).toBeInTheDocument();
+    expect(screen.getByText('Line three')).toBeInTheDocument();
+  });
+
+  it('links the primary CTA to the projects section', () => {
+    render(<Hero username="octocat" />);
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(screen.getByText('View Projects').closest('a')).toHaveAttribute(
+      'href',
+      '#projects'
+    );
+  });
+
+  it('points the social links at the given username', () => {
+    render(<Hero username="octocat" />);
+    expect(screen.getByLabelText('GitHub')).toHaveAttribute(
+      'href',
+      'https://github.com/octocat'
+    );
+    expect(screen.getByLabelText('LinkedIn')).toHaveAttribute(
+      'href',
+      'https://linkedin.com/in/octocat'
+    );
+    expect(screen.getByLabelText('Email')).toHaveAttribute('href', '#contact');
+  });
+
+  it('renders the first rotating role', () => {
+    render(<Hero username="octocat" />);
+    expect(screen.getByText('Backend Engineer')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/portfolio/Languages.test.tsx
+++ b/src/__tests__/portfolio/Languages.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { LanguageDatum } from '@/components/portfolio/Languages';
+import LanguagesSection from '@/components/portfolio/Languages';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const data: LanguageDatum[] = [
+  { name: 'TypeScript', hours: 4000, color: '#2b7489' },
+  { name: 'Java', hours: 2500, color: '#b07219' },
+];
+
+describe('LanguagesSection', () => {
+  it('renders nothing with no data', () => {
+    const { container } = render(<LanguagesSection data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders each language name and its total hours', () => {
+    render(<LanguagesSection data={data} />);
+    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Java').length).toBeGreaterThan(0);
+    expect(screen.getByText(/6,?500/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/portfolio/Nav.test.tsx
+++ b/src/__tests__/portfolio/Nav.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import Nav from '@/components/portfolio/Nav';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { locale: 'en' } }),
+}));
+
+describe('Nav', () => {
+  it('renders the brand name', () => {
+    render(<Nav />);
+    expect(screen.getAllByText('lucasheartcliff').length).toBeGreaterThan(0);
+  });
+
+  it('renders every nav link', () => {
+    render(<Nav />);
+    [
+      'nav.about',
+      'nav.architecture',
+      'nav.stack',
+      'nav.languages',
+      'nav.projects',
+      'nav.writing',
+      'nav.contact',
+    ].forEach((key) => {
+      expect(screen.getAllByText(key).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('opens and closes the mobile drawer', () => {
+    render(<Nav />);
+    expect(screen.queryByLabelText('Close menu')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    const closeButton = screen.getByLabelText('Close menu');
+    expect(closeButton).toBeInTheDocument();
+
+    fireEvent.click(closeButton);
+    expect(screen.queryByLabelText('Close menu')).not.toBeInTheDocument();
+  });
+
+  it('links the CTA to the contact section', () => {
+    render(<Nav />);
+    const ctas = screen.getAllByText('cta.getInTouch');
+    ctas.forEach((cta) => {
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(cta.closest('a')).toHaveAttribute('href', '#contact');
+    });
+  });
+
+  it('switches locale from the language toggle', () => {
+    const original = window.location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = { assign: jest.fn() };
+
+    render(<Nav />);
+    fireEvent.click(screen.getAllByText('pt')[0]!);
+    expect(window.location.assign).toHaveBeenCalledWith('/pt');
+
+    window.location = original;
+  });
+});

--- a/src/__tests__/portfolio/Nav.test.tsx
+++ b/src/__tests__/portfolio/Nav.test.tsx
@@ -62,10 +62,12 @@ describe('Nav', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).location = { assign: jest.fn() };
 
-    render(<Nav />);
-    fireEvent.click(screen.getAllByText('pt')[0]!);
-    expect(window.location.assign).toHaveBeenCalledWith('/pt');
-
-    window.location = original;
+    try {
+      render(<Nav />);
+      fireEvent.click(screen.getAllByText('pt')[0]!);
+      expect(window.location.assign).toHaveBeenCalledWith('/pt');
+    } finally {
+      window.location = original;
+    }
   });
 });

--- a/src/__tests__/portfolio/Projects.test.tsx
+++ b/src/__tests__/portfolio/Projects.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { ProjectDatum } from '@/components/portfolio/Projects';
+import ProjectsSection from '@/components/portfolio/Projects';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const project: ProjectDatum = {
+  name: 'cool-repo',
+  desc: 'A cool repo',
+  tags: ['typescript', 'nextjs'],
+  stars: 12,
+  forks: 3,
+  lang: 'TypeScript',
+  langColor: '#2b7489',
+  url: 'https://github.com/octocat/cool-repo',
+  featured: true,
+};
+
+describe('ProjectsSection', () => {
+  it('renders nothing when there are no projects', () => {
+    const { container } = render(<ProjectsSection projects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a project card with its stats, tags, and link', () => {
+    render(<ProjectsSection projects={[project]} username="octocat" />);
+    expect(screen.getByText('cool-repo')).toBeInTheDocument();
+    expect(screen.getByText('A cool repo')).toBeInTheDocument();
+    expect(screen.getByText('typescript')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const link = screen.getByText('cool-repo').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/octocat/cool-repo'
+    );
+  });
+
+  it('links "all repos" to the given username GitHub profile', () => {
+    render(<ProjectsSection projects={[project]} username="octocat" />);
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(screen.getByText('proj.allRepos').closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/octocat'
+    );
+  });
+});

--- a/src/__tests__/portfolio/Stack.test.tsx
+++ b/src/__tests__/portfolio/Stack.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import StackSection from '@/components/portfolio/Stack';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('StackSection', () => {
+  it('renders every stack category label and a sample of items', () => {
+    render(<StackSection />);
+    expect(screen.getByText('stack.cat.backend')).toBeInTheDocument();
+    expect(screen.getByText('stack.cat.frontend')).toBeInTheDocument();
+    expect(screen.getByText('stack.cat.data')).toBeInTheDocument();
+    expect(screen.getByText('stack.cat.cloud')).toBeInTheDocument();
+    expect(screen.getByText('Java')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('Kubernetes')).toBeInTheDocument();
+  });
+
+  it('renders the summary metrics', () => {
+    render(<StackSection />);
+    expect(screen.getByText('9+')).toBeInTheDocument();
+    expect(screen.getByText('99.97%')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/portfolio/atoms.test.tsx
+++ b/src/__tests__/portfolio/atoms.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  Glass,
+  Reveal,
+  SectionLabel,
+  Tag,
+  Trans,
+} from '@/components/portfolio/atoms';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const dict: Record<string, string> = {
+        'hero.bio': 'Building {b}scalable{/b} systems.',
+      };
+      return dict[key] ?? key;
+    },
+  }),
+}));
+
+describe('Glass', () => {
+  it('renders children with the glass-card class plus any extra className', () => {
+    render(<Glass className="extra">content</Glass>);
+    expect(screen.getByText('content')).toHaveClass('glass-card', 'extra');
+  });
+});
+
+describe('Tag', () => {
+  it('renders its children', () => {
+    render(<Tag accent="#123456">Kafka</Tag>);
+    expect(screen.getByText('Kafka')).toBeInTheDocument();
+  });
+});
+
+describe('SectionLabel', () => {
+  it('renders the number and label', () => {
+    render(<SectionLabel num="01" label="Architecture" />);
+    expect(screen.getByText('01')).toBeInTheDocument();
+    expect(screen.getByText('Architecture')).toBeInTheDocument();
+  });
+});
+
+describe('Reveal', () => {
+  it('renders its children', () => {
+    render(
+      <Reveal>
+        <span>revealed content</span>
+      </Reveal>
+    );
+    expect(screen.getByText('revealed content')).toBeInTheDocument();
+  });
+});
+
+describe('Trans', () => {
+  it('renders {b}...{/b} segments as <strong>', () => {
+    render(<Trans k="hero.bio" />);
+    const strong = screen.getByText('scalable');
+    expect(strong.tagName).toBe('STRONG');
+  });
+
+  it('renders the surrounding text as plain text', () => {
+    render(<Trans k="hero.bio" />);
+    expect(screen.getByText(/Building/)).toBeInTheDocument();
+    expect(screen.getByText(/systems\./)).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,8 +37,8 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
+      "@/public/*": ["./public/*"],
+      "@/*": ["./src/*"]
     }
   },
   "exclude": ["./out/**/*", "./node_modules/**/*", "cypress/**/*.ts"],


### PR DESCRIPTION
## Summary
Every test in the suite covered components from the site's earlier per-page design, none of which are reachable from either live page (`pages/[locale]/index.tsx`, `pages/articles/[slug].tsx`). The actual site — everything a visitor sees — had 0% test coverage.

- Adds unit tests for the components that make up the live homepage: `atoms` (`Glass`, `Tag`, `SectionLabel`, `Reveal`, `Trans`), `Hero`, `Nav`, `Contact`, `Architecture`, `Stack`, `Projects`, `Articles`, `Languages`
- Adds smoke tests for both live pages (`pages/[locale]/index.tsx`, `pages/articles/[slug].tsx`), covering the loaded/not-found states and confirming the right API calls fire on mount
- Coverage on `src/components/portfolio/*` goes from 0% to ~90% statements

**Two config bugs fixed along the way** (found because these are the first tests to import the page components, which transitively pull in `Meta.tsx`'s `@/public/*` import):
- `jest.config.js`'s `moduleNameMapper` listed the general `^@/(.*)$` pattern before the more specific `^@/public/(.*)$` one, so every `@/public/*` import silently resolved into `src/public/...` (which doesn't exist) instead of the real `public/` directory
- `tsconfig.json`'s `paths` had the same ordering. `tsc` itself never surfaced this because it falls back to whichever path candidate actually resolves to a real file, but SWC's alias-resolution transform (used by `next/jest`) doesn't have that fallback

Reordering both (specific pattern before general) fixes it without changing any existing behavior — `npm run build` and `tsc --noEmit` both verified clean before and after.

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 38/38 suites, 139/139 tests pass
- [x] `npm run build` — verified a full production build still succeeds after the `tsconfig.json` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_