### PR TITLE
Firefox/Safari compatibility and scroll/animation performance

### DIFF
--- a/src/components/ReactiveBackground/index.tsx
+++ b/src/components/ReactiveBackground/index.tsx
@@ -80,8 +80,7 @@ const ReactiveDotGrid = ({
     resize();
     window.addEventListener('resize', resize);
 
-    const tick = (t: number) => {
-      const time = t * 0.001;
+    const draw = (time: number) => {
       const { w, h } = sizeRef.current;
       ctx.clearRect(0, 0, w, h);
       const dots = dotsRef.current;
@@ -100,7 +99,32 @@ const ReactiveDotGrid = ({
         ctx.arc(d.x, d.y, d.r, 0, Math.PI * 2);
         ctx.fill();
       }
+    };
 
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+
+    if (reduceMotion) {
+      // Static render only: respects the user's preference and skips the
+      // render loop entirely rather than just holding it at a low rate.
+      draw(0);
+      return () => window.removeEventListener('resize', resize);
+    }
+
+    // The breathing effect is a slow sine wave — redrawing ~1300+ dots at a
+    // throttled ~30fps instead of a full 60fps halves this loop's main-thread
+    // cost (canvas 2D drawing isn't compositor-offloaded like CSS transforms
+    // are) without a perceptible difference, which matters most while
+    // scrolling: this fixed, full-viewport canvas competes with the
+    // browser's scroll work on the same thread every frame it redraws.
+    const FRAME_INTERVAL = 1000 / 30;
+    let lastDraw = 0;
+    const tick = (t: number) => {
+      if (t - lastDraw >= FRAME_INTERVAL) {
+        lastDraw = t;
+        draw(t * 0.001);
+      }
       rafRef.current = requestAnimationFrame(tick);
     };
     rafRef.current = requestAnimationFrame(tick);
@@ -133,6 +157,15 @@ const AmbientOrbs = ({
     className="pointer-events-none fixed inset-0 overflow-hidden"
     style={{ zIndex: 0, opacity: intensity }}
   >
+    {/*
+      will-change promotes each orb to its own compositor layer up front
+      instead of on first transform (avoiding a jank spike when the
+      animation starts), and the blur radii are deliberately kept modest:
+      filter: blur() forces the browser to rasterize a bitmap larger than
+      the element's own bounds, and these are large (45-60vw), fixed-position,
+      continuously-animated elements — the single most expensive combination
+      to keep composited every frame, on Firefox in particular.
+    */}
     <div
       className="orb-anim-1 absolute rounded-full"
       style={{
@@ -141,7 +174,8 @@ const AmbientOrbs = ({
         top: '-15vw',
         left: '-10vw',
         background: `radial-gradient(circle at 30% 30%, ${palette[0]}55, transparent 65%)`,
-        filter: 'blur(60px)',
+        filter: 'blur(45px)',
+        willChange: 'transform',
       }}
     />
     <div
@@ -152,7 +186,8 @@ const AmbientOrbs = ({
         top: '20vh',
         right: '-20vw',
         background: `radial-gradient(circle at 50% 50%, ${palette[1]}55, transparent 65%)`,
-        filter: 'blur(70px)',
+        filter: 'blur(50px)',
+        willChange: 'transform',
       }}
     />
     <div
@@ -163,7 +198,8 @@ const AmbientOrbs = ({
         bottom: '-15vw',
         left: '20vw',
         background: `radial-gradient(circle at 50% 50%, ${palette[2]}55, transparent 65%)`,
-        filter: 'blur(60px)',
+        filter: 'blur(45px)',
+        willChange: 'transform',
       }}
     />
     <div

--- a/src/components/portfolio/Architecture.tsx
+++ b/src/components/portfolio/Architecture.tsx
@@ -302,7 +302,9 @@ export default function ArchitectureSection({
             <span
               style={{
                 background: `linear-gradient(120deg, ${accent}, ${accentB})`,
+                backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
+                color: 'transparent',
                 WebkitTextFillColor: 'transparent',
               }}
             >

--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -191,7 +191,9 @@ export default function ContactSection({
             <span
               style={{
                 background: `linear-gradient(120deg, ${accent}, ${accentB})`,
+                backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
+                color: 'transparent',
                 WebkitTextFillColor: 'transparent',
               }}
             >

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -208,7 +208,9 @@ export default function Hero({
                 className="block -mb-[0.12em] pb-[0.12em]"
                 style={{
                   background: `linear-gradient(120deg, ${accent}, ${accentB})`,
+                  backgroundClip: 'text',
                   WebkitBackgroundClip: 'text',
+                  color: 'transparent',
                   WebkitTextFillColor: 'transparent',
                 }}
               >

--- a/src/components/portfolio/Stack.tsx
+++ b/src/components/portfolio/Stack.tsx
@@ -152,7 +152,9 @@ export default function StackSection({
                       i % 2 === 0
                         ? `linear-gradient(120deg, ${accent}, ${accentB})`
                         : `linear-gradient(120deg, ${accentB}, ${accent})`,
+                    backgroundClip: 'text',
                     WebkitBackgroundClip: 'text',
+                    color: 'transparent',
                     WebkitTextFillColor: 'transparent',
                   }}
                 >

--- a/src/pages/articles/[slug].tsx
+++ b/src/pages/articles/[slug].tsx
@@ -121,10 +121,16 @@ const ReadingProgress = ({ accent }: { accent: string }) => {
   const { t } = useTranslation('common');
   const [p, setP] = useState(0);
   useEffect(() => {
+    let ticking = false;
     const onScroll = () => {
-      const h = document.documentElement;
-      const pct = h.scrollTop / (h.scrollHeight - h.clientHeight || 1);
-      setP(Math.max(0, Math.min(1, pct)));
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const h = document.documentElement;
+        const pct = h.scrollTop / (h.scrollHeight - h.clientHeight || 1);
+        setP(Math.max(0, Math.min(1, pct)));
+        ticking = false;
+      });
     };
     window.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
@@ -160,13 +166,19 @@ const TocAside = ({
   const { t } = useTranslation('common');
   const [active, setActive] = useState(toc[0]?.id ?? '');
   useEffect(() => {
+    let ticking = false;
     const onScroll = () => {
-      let cur = toc[0]?.id ?? '';
-      toc.forEach((item) => {
-        const el = document.getElementById(item.id);
-        if (el && el.getBoundingClientRect().top < 200) cur = item.id;
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        let cur = toc[0]?.id ?? '';
+        toc.forEach((item) => {
+          const el = document.getElementById(item.id);
+          if (el && el.getBoundingClientRect().top < 200) cur = item.id;
+        });
+        setActive(cur);
+        ticking = false;
       });
-      setActive(cur);
     };
     window.addEventListener('scroll', onScroll, { passive: true });
     onScroll();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,6 +101,7 @@ a {
   background: var(--toggle-bg);
   border: 1px solid var(--toggle-border);
   backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   color: var(--text-strong);
 }
 .glass-btn:hover {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,9 +45,18 @@ body,
   overflow-x: hidden;
 }
 
+/* Firefox doesn't support ::-webkit-scrollbar; this is its native
+   equivalent for the same thin, muted scrollbar (see ::-webkit-scrollbar
+   below). Chromium/Safari ignore these two properties. */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: var(--chip-border) transparent;
+}
+
 body {
   font-family: 'Space Grotesk', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
 
@@ -294,6 +303,10 @@ section[id] {
 .code-block pre::-webkit-scrollbar-thumb {
   background: var(--chip-border);
   border-radius: 4px;
+}
+.code-block pre {
+  scrollbar-width: thin;
+  scrollbar-color: var(--chip-border) transparent;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
Two related passes, both scoped by real constraints in this sandbox: no Firefox or Safari binaries are available here (Safari doesn't run on Linux at all), so everything below is a code-level audit + standard, well-established fixes, not something I could directly observe in either engine.

**CSS compatibility** (original scope of this PR):
- Gradient headline text (Hero, Architecture, Stack, Contact) only set `WebkitBackgroundClip`/`WebkitTextFillColor`, no standard fallback. Added `backgroundClip: 'text'` + `color: 'transparent'`, which Firefox has supported natively since 2016 — this doesn't depend on Firefox's newer, non-standard `-webkit-` prefix alias shim.
- `::-webkit-scrollbar` has no effect in Firefox; added the native `scrollbar-width`/`scrollbar-color` equivalent for the page and code-block scrollbars.
- Paired `-webkit-font-smoothing` with `-moz-osx-font-smoothing: grayscale` for macOS Firefox.

**Scroll/animation performance** (added after a report of lag while scrolling and during animations in Firefox):
- `ReactiveDotGrid`'s canvas redraw (~1300+ dots) ran on the main thread every single animation frame, forever — competing directly with the browser's scroll work. Throttled to ~30fps (imperceptible for this slow breathing effect) and skips the loop entirely (renders once, statically) when `prefers-reduced-motion` is set.
- `AmbientOrbs` — large, fixed, continuously-animated, blurred elements are one of the most expensive things to keep composited every frame. Reduced blur radii modestly (60-70px → 45-50px) and added `will-change: transform` so each orb gets its own compositor layer up front.
- The article page's two scroll handlers (reading progress, active-TOC tracking) ran unthrottled on every scroll event; the TOC one calls `getBoundingClientRect()` (layout-forcing) in a loop over every heading. Both now batch to one update per animation frame instead of potentially dozens of forced synchronous layouts per second.
- `.glass-btn`'s `backdrop-filter` was missing its `-webkit-backdrop-filter` pairing that every other `.glass-*` rule already had — a real gap specifically for Safari.

## Honesty about verification
I attempted to get empirical before/after evidence for the performance changes via a CPU-throttled synthetic scroll in Chromium (Long Tasks API, 4x slowdown). The first comparison looked favorable, but repeated runs of both the old and new code landed within noise of each other on this VM — so I'm **not** claiming a measured speedup I can't actually substantiate. What's here is standard, well-established, and strictly no-downside (fewer redundant redraws, no forced-synchronous-layout loops, smaller blur rasterization, added compositor hints). Real verification of the original lag report still needs an actual Firefox/Safari session on a real device — I'd recommend confirming there before/after with browser dev tools' performance profiler if the lag is still noticeable after this lands.

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (only a pre-existing, unrelated warning in `Hero.tsx`)
- [x] `npm test` — 17/17 suites, 80/80 tests pass
- [x] `npm run build` — succeeds
- [x] Verified in Chromium that the gradient-text fix computes correctly (`background-clip: text`, `color: rgba(0,0,0,0)`) with zero visual change there
- [x] New CSS properties confirmed present in the production build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
