### PR TITLE
ci: cancel superseded runs and cache Docker layers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -33,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
@@ -53,6 +60,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     needs: build-and-push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Portfolio
 
+[![Build & Deploy](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml)
+
 A personal portfolio website built with Next.js 13, TypeScript, and Tailwind CSS. Showcases professional experience, technical skills, certifications, articles, and open-source projects with bilingual support (English and Portuguese).
 
 **Live**: [lucasheartcliff.com.br](https://lucasheartcliff.com.br)


### PR DESCRIPTION
## Summary
- Add a `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) to `deploy.yml` so pushing new commits to the same branch/PR cancels the previous in-flight run instead of letting both race to completion — saves runner minutes on rapid pushes.
- Add `docker/setup-buildx-action` and wire `cache-from`/`cache-to: type=gha` into the `build-push-action` step so Docker layers (deps install, base images) are cached across CI runs via the GitHub Actions cache instead of rebuilding from scratch every time.

## Test plan
- [ ] Confirm CI runs green on this PR
- [ ] Confirm a second push to this branch cancels the first run (visible in the Actions tab)
- [ ] Confirm a subsequent run after a merge shows reduced Docker build time from cache hits


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_