### PR TITLE
docs/perf: Lighthouse scores (desktop+mobile), browser support, mobile perf fixes

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,23 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lighthouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn test --passWithNoTests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Portfolio
 
+[![Tests](https://github.com/lucasheartcliff/portfolio/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/test.yml)
 [![Build & Deploy](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml)
 [![Lighthouse CI](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml)
 [![Performance](https://img.shields.io/badge/Lighthouse%20Performance-97-brightgreen)](#lighthouse-scores)
@@ -252,11 +253,12 @@ docker run -p 3000:3000 --env-file .env.local portfolio
 
 ### CI/CD
 
-The GitHub Actions workflow (`.github/workflows/deploy.yml`) runs on push to `main`/`next`:
-
-1. **Test** — Install, lint, run unit tests
-2. **Build & Push** — Build Docker image, push to GitHub Container Registry (GHCR)
-3. **Deploy** — SSH into server, pull latest image, restart with `docker compose`
+- **`.github/workflows/test.yml`** — Install, lint, run unit tests. Runs on push/PR to `main`/`next`; this is the **Tests** badge above.
+- **`.github/workflows/deploy.yml`** — Runs on push to `main`/`next`:
+  1. **Test** — Install, lint, run unit tests (duplicated from `test.yml` so `build-and-push`/`deploy` can depend on it within the same workflow run)
+  2. **Build & Push** — Build Docker image, push to GitHub Container Registry (GHCR)
+  3. **Deploy** — SSH into server, pull latest image, restart with `docker compose`
+- **`.github/workflows/lighthouse.yml`** — Runs `yarn lighthouse` (Lighthouse CI) on push/PR to `main`/`next`; this is the **Lighthouse CI** badge above.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Portfolio
 
 [![Build & Deploy](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml)
+[![Lighthouse CI](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml)
+[![Performance](https://img.shields.io/badge/Lighthouse%20Performance-97-brightgreen)](#lighthouse-scores)
+[![Accessibility](https://img.shields.io/badge/Lighthouse%20Accessibility-100-brightgreen)](#lighthouse-scores)
+[![Best Practices](https://img.shields.io/badge/Lighthouse%20Best%20Practices-96-brightgreen)](#lighthouse-scores)
+[![SEO](https://img.shields.io/badge/Lighthouse%20SEO-100-brightgreen)](#lighthouse-scores)
 
 A personal portfolio website built with Next.js 13, TypeScript, and Tailwind CSS. Showcases professional experience, technical skills, certifications, articles, and open-source projects with bilingual support (English and Portuguese).
 
@@ -88,6 +93,35 @@ Dedicated page (`/articles/[slug]`) that fetches and renders full Dev.to article
 | **Git Hooks** | Husky, lint-staged, Commitlint (Conventional Commits) |
 | **Build** | Next.js compiler, @next/bundle-analyzer |
 | **Deployment** | Docker (multi-stage), Nginx reverse proxy, GitHub Actions CI/CD |
+
+---
+
+## Lighthouse Scores
+
+Audited locally against a production build (`next build && next start`) using the [`lighthouserc.js`](lighthouserc.js) config — 3 runs each on `/en` and `/pt`, desktop preset, averaged:
+
+| Category | Score |
+|----------|-------|
+| Performance | 97 |
+| Accessibility | 100 |
+| Best Practices | 96 |
+| SEO | 100 |
+
+Enforced in CI via the **Lighthouse CI** workflow (badge above) on every push/PR to `main`/`next`: Accessibility, Best Practices, and SEO are hard-gated (`error`, real `minScore` thresholds) since they're deterministic markup/DOM checks. Performance is `warn`-only — the performance *category* score mixes timing metrics that are sensitive to whatever CPU the audit happens to run on, so it's tracked but doesn't block merges without a dedicated, stable runner behind it. Re-run locally anytime with `yarn lighthouse`.
+
+---
+
+## Browser Support
+
+Targets are defined by the [`browserslist`](package.json) config (`> 0.5%, last 2 versions, not dead, not ie 11, not op_mini all`) and enforced at build time via Autoprefixer/PostCSS.
+
+| Browser | Notes |
+|---------|-------|
+| Chrome / Edge (Chromium) | Primary development and testing target |
+| Firefox | Supported — includes Firefox-specific CSS fallbacks (`scrollbar-width`, native `background-clip: text`, `-moz-osx-font-smoothing`) |
+| Safari (macOS / iOS) | Supported — includes `-webkit-` prefixes for `backdrop-filter` and gradient text |
+
+Internet Explorer 11 and Opera Mini are explicitly excluded.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Tests](https://github.com/lucasheartcliff/portfolio/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/test.yml)
 [![Build & Deploy](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/deploy.yml)
 [![Lighthouse CI](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml/badge.svg?branch=main)](https://github.com/lucasheartcliff/portfolio/actions/workflows/lighthouse.yml)
-[![Performance](https://img.shields.io/badge/Lighthouse%20Performance-97-brightgreen)](#lighthouse-scores)
+[![Performance (desktop)](https://img.shields.io/badge/Lighthouse%20Performance%20%28desktop%29-100-brightgreen)](#lighthouse-scores)
+[![Performance (mobile)](https://img.shields.io/badge/Lighthouse%20Performance%20%28mobile%29-88-yellowgreen)](#lighthouse-scores)
 [![Accessibility](https://img.shields.io/badge/Lighthouse%20Accessibility-100-brightgreen)](#lighthouse-scores)
 [![Best Practices](https://img.shields.io/badge/Lighthouse%20Best%20Practices-96-brightgreen)](#lighthouse-scores)
 [![SEO](https://img.shields.io/badge/Lighthouse%20SEO-100-brightgreen)](#lighthouse-scores)
@@ -18,7 +19,7 @@ A personal portfolio website built with Next.js 13, TypeScript, and Tailwind CSS
 
 ### Page Sections
 
-- **Hero** — Name, animated rotating role titles (Framer Motion), social links (GitHub, LinkedIn, Email), availability badge, and downloadable PDF resume
+- **Hero** — Name, animated rotating role titles (CSS transitions), social links (GitHub, LinkedIn, Email), availability badge, and downloadable PDF resume
 - **About** — Professional summary with profile photo
 - **Languages** — Interactive horizontal bar chart (ApexCharts) showing programming language experience time sourced from WakaTime
 - **Tech Stack** — Grid of technologies organized by category (Backend, Frontend, Database, DevOps, Infrastructure) with devicon images
@@ -43,7 +44,7 @@ Dedicated page (`/articles/[slug]`) that fetches and renders full Dev.to article
 ### UI/UX
 
 - **Dark Mode** — Toggle in navbar, persisted in localStorage, respects system `prefers-color-scheme`, applies Tailwind `dark:` classes and Ant Design dark algorithm
-- **Scroll Animations** — `Reveal` component wraps sections with Framer Motion fade-in + slide-up triggered on scroll (viewport intersection, fires once)
+- **Scroll Animations** — `Reveal` component wraps sections with a CSS fade-in + slide-up triggered on scroll (`IntersectionObserver`, fires once); an `eager` mode skips this for above-the-fold content so it isn't gated behind hydration
 - **Scroll-to-Top Button** — Appears after 300px scroll, smooth scrolls to top
 - **Aside Navigation** — Collapsible side panel with section links, scroll-spy active state highlighting, and smooth scroll-to-section
 - **Loading Screen** — Animated splash screen with spinner and name on initial page load
@@ -82,7 +83,7 @@ Dedicated page (`/articles/[slug]`) that fetches and renders full Dev.to article
 |-------|-------------|
 | **Framework** | Next.js 13 (Pages Router), React 18, TypeScript |
 | **Styling** | Tailwind CSS 3, Ant Design 5 |
-| **Animations** | Framer Motion |
+| **Animations** | CSS transitions + `IntersectionObserver` (no animation library) |
 | **Charts** | ApexCharts (react-apexcharts) |
 | **Markdown** | react-markdown |
 | **i18n** | next-i18next, react-i18next, i18next |
@@ -99,16 +100,26 @@ Dedicated page (`/articles/[slug]`) that fetches and renders full Dev.to article
 
 ## Lighthouse Scores
 
-Audited locally against a production build (`next build && next start`) using the [`lighthouserc.js`](lighthouserc.js) config — 3 runs each on `/en` and `/pt`, desktop preset, averaged:
+Audited locally against a production build (`next build && next start`) — 3 runs each on `/en` and `/pt`, averaged — using [`lighthouserc.desktop.js`](lighthouserc.desktop.js) (desktop preset) and [`lighthouserc.mobile.js`](lighthouserc.mobile.js) (Lighthouse's default mobile emulation: 360×640, 4x CPU slowdown, throttled network — the same profile PageSpeed Insights reports as "Mobile"):
 
-| Category | Score |
-|----------|-------|
-| Performance | 97 |
-| Accessibility | 100 |
-| Best Practices | 96 |
-| SEO | 100 |
+| Category | Desktop | Mobile |
+|----------|:-------:|:------:|
+| Performance | 100 | 88 |
+| Accessibility | 100 | 100 |
+| Best Practices | 96 | 96 |
+| SEO | 100 | 100 |
 
-Enforced in CI via the **Lighthouse CI** workflow (badge above) on every push/PR to `main`/`next`: Accessibility, Best Practices, and SEO are hard-gated (`error`, real `minScore` thresholds) since they're deterministic markup/DOM checks. Performance is `warn`-only — the performance *category* score mixes timing metrics that are sensitive to whatever CPU the audit happens to run on, so it's tracked but doesn't block merges without a dedicated, stable runner behind it. Re-run locally anytime with `yarn lighthouse`.
+Mobile was audited for the first time alongside this table and came in well below desktop (80 performance), so it got a real optimization pass rather than just a number:
+
+- **Self-hosted fonts** via `next/font/google` (`src/styles/fonts.ts`) instead of a `<link>` to `fonts.googleapis.com` — no third-party font request at all, and dropped an entirely unused Instrument Serif family that was being downloaded and never applied anywhere.
+- **`Reveal eager` mode** (`src/components/portfolio/atoms.tsx`) — the hero section's content was wrapped in the same scroll-triggered fade-in as every other section, but the hero is fully above the fold on load; it was paying a hydration + `IntersectionObserver` + 900ms-transition tax to reveal content nobody had to scroll to see. `eager` skips that entirely for above-the-fold content. This was the single biggest fix: it was the LCP element, at 4.0s.
+- **Removed `framer-motion` and `@ant-design/icons`** — both were imported only by the loading spinner shown before hydration on every page load, replaced with a plain CSS spinner + fade. Dropped the shared `_app.js` chunk from 133 kB to 88.3 kB.
+- **Removed the unused `flag-icons` stylesheet** — imported globally but no flag icon is ever rendered (the locale switcher uses plain text). Dropped shared CSS from 13.5 kB to 6.83 kB.
+- **Pointed the audit at the canonical URLs** (`/en/`, `/pt/` instead of `/en`, `/pt`) — `trailingSlash: true` means the bare path always 308-redirects to the trailing-slash form, which Lighthouse was counting as 610ms of pure waste on every run.
+
+Best Practices is capped at 96/100 in *this* sandboxed environment specifically — the failing audit (`errors-in-console`) is network-level "failed to load resource" logs from Google Tag Manager, this project's own `/api/wakatime` and `/api/github` proxy routes (no real API credentials configured locally), and Vercel's insights script (only resolves when actually hosted on Vercel). None are real code defects; a deployment with real credentials and open internet access should score 100 there too.
+
+Enforced in CI via the **Lighthouse CI** workflow (badge above) on every push/PR to `main`/`next`: Accessibility, Best Practices, and SEO are hard-gated (`error`, real `minScore` thresholds) since they're deterministic markup/DOM checks. Performance is `warn`-only — the performance *category* score mixes timing metrics that are sensitive to whatever CPU the audit happens to run on, so it's tracked but doesn't block merges without a dedicated, stable runner behind it. Re-run locally anytime with `yarn lighthouse` (both) or `yarn lighthouse:desktop` / `yarn lighthouse:mobile` individually.
 
 ---
 

--- a/lighthouserc.desktop.js
+++ b/lighthouserc.desktop.js
@@ -7,7 +7,7 @@ module.exports = {
       startServerCommand: 'npm run start',
       startServerReadyPattern: 'Ready in',
       startServerReadyTimeout: 30000,
-      url: ['http://localhost:3000/en', 'http://localhost:3000/pt'],
+      url: ['http://localhost:3000/en/', 'http://localhost:3000/pt/'],
       numberOfRuns: 3,
       settings: {
         preset: 'desktop',

--- a/lighthouserc.desktop.js
+++ b/lighthouserc.desktop.js
@@ -33,7 +33,7 @@ module.exports = {
     },
     upload: {
       target: 'filesystem',
-      outputDir: '.lighthouseci',
+      outputDir: '.lighthouseci/desktop',
     },
   },
 };

--- a/lighthouserc.mobile.js
+++ b/lighthouserc.mobile.js
@@ -1,0 +1,42 @@
+module.exports = {
+  ci: {
+    collect: {
+      // A production build, not `next dev` — dev mode ships unminified JS
+      // and skips caching headers, which tanks performance numbers for
+      // reasons that have nothing to do with real-world behavior.
+      startServerCommand: 'npm run start',
+      startServerReadyPattern: 'Ready in',
+      startServerReadyTimeout: 30000,
+      url: ['http://localhost:3000/en', 'http://localhost:3000/pt'],
+      numberOfRuns: 3,
+      settings: {
+        // No `preset` — Lighthouse's default (no preset) is its standard
+        // mobile emulation: 360x640 viewport, 4x CPU slowdown, simulated
+        // slow-4G-ish throttling. This is what PageSpeed Insights reports
+        // as "Mobile" by default.
+        // --no-sandbox is required in containers that run Chrome as root
+        // (e.g. most CI images); harmless elsewhere.
+        chromeFlags: ['--no-sandbox'],
+      },
+    },
+    assert: {
+      assertions: {
+        // Accessibility, best-practices, and SEO are deterministic (DOM/
+        // markup checks, not wall-clock timing), so hold them to a real
+        // bar. Performance *category* score mixes several timing metrics
+        // that are highly sensitive to the CPU the audit happens to run
+        // on — assert on it locally if you want a sanity check, but don't
+        // wire it into anything that gates merges without a stable,
+        // dedicated runner behind it.
+        'categories:accessibility': ['error', { minScore: 0.95 }],
+        'categories:best-practices': ['error', { minScore: 0.9 }],
+        'categories:seo': ['error', { minScore: 0.95 }],
+        'categories:performance': ['warn', { minScore: 0.8 }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: '.lighthouseci/mobile',
+    },
+  },
+};

--- a/lighthouserc.mobile.js
+++ b/lighthouserc.mobile.js
@@ -7,7 +7,7 @@ module.exports = {
       startServerCommand: 'npm run start',
       startServerReadyPattern: 'Ready in',
       startServerReadyTimeout: 30000,
-      url: ['http://localhost:3000/en', 'http://localhost:3000/pt'],
+      url: ['http://localhost:3000/en/', 'http://localhost:3000/pt/'],
       numberOfRuns: 3,
       settings: {
         // No `preset` — Lighthouse's default (no preset) is its standard

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "antd": "5.11.5",
     "apexcharts": "3.28.1",
     "fetch-jsonp": "1.2.3",
-    "flag-icons": "^7.1.0",
     "i18next": "^23.10.0",
     "lucide-react": "^0.577.0",
     "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lighthouse:mobile": "lhci autorun --config=lighthouserc.mobile.js"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.0.0",
     "@next/third-parties": "^14.1.4",
     "@react-pdf/renderer": "^4.1.6",
     "@vercel/analytics": "^2.0.1",
@@ -33,7 +32,6 @@
     "apexcharts": "3.28.1",
     "fetch-jsonp": "1.2.3",
     "flag-icons": "^7.1.0",
-    "framer-motion": "^12.35.2",
     "i18next": "^23.10.0",
     "lucide-react": "^0.577.0",
     "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "prepare": "husky install",
     "postbuild": "next-sitemap",
     "lighthouse": "run-s build lighthouse:ci",
-    "lighthouse:ci": "lhci autorun"
+    "lighthouse:ci": "run-s lighthouse:desktop lighthouse:mobile",
+    "lighthouse:desktop": "lhci autorun --config=lighthouserc.desktop.js",
+    "lighthouse:mobile": "lhci autorun --config=lighthouserc.mobile.js"
   },
   "dependencies": {
     "@ant-design/icons": "^5.0.0",

--- a/src/components/LoadingScreen/index.tsx
+++ b/src/components/LoadingScreen/index.tsx
@@ -1,6 +1,3 @@
-import { LoadingOutlined } from '@ant-design/icons';
-import { Spin } from 'antd';
-import { motion } from 'framer-motion';
 import React from 'react';
 
 type Props = {
@@ -9,33 +6,38 @@ type Props = {
 
 const LoadingScreen = ({ name }: Props) => {
   return (
-    <motion.div
+    <div
       role="status"
       aria-live="polite"
       aria-label="Loading"
-      initial={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.5, ease: 'easeInOut' }}
       className="fixed inset-0 z-[9999] flex flex-col items-center justify-center"
       style={{ background: 'var(--bg-base)' }}
     >
-      <Spin
-        indicator={
-          <LoadingOutlined
-            style={{ fontSize: 48, color: 'var(--accent)' }}
-            spin
-          />
-        }
-      />
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.5 }}
+      <svg
+        className="animate-spin"
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="var(--accent)"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeDasharray="55"
+          strokeDashoffset="15"
+        />
+      </svg>
+      <p
         className="mt-4 font-display text-xl font-semibold tracking-widest text-primary"
+        style={{ animation: 'loadingTextIn 0.4s ease-out 0.5s both' }}
       >
         {name}
-      </motion.p>
-    </motion.div>
+      </p>
+    </div>
   );
 };
 

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -178,7 +178,7 @@ export default function Hero({
     >
       <div className="mx-auto grid w-full max-w-6xl items-center gap-8 px-5 sm:px-6 lg:grid-cols-[1.4fr_1fr] lg:gap-12">
         <div>
-          <Reveal>
+          <Reveal eager>
             <div
               className="mb-8 inline-flex items-center gap-2 rounded-full px-3 py-1.5"
               style={{
@@ -201,11 +201,11 @@ export default function Hero({
             </div>
           </Reveal>
 
-          <Reveal delay={80}>
+          <Reveal eager delay={80}>
             <h1 className="font-display text-[clamp(40px,11vw,104px)] font-semibold leading-[0.95] tracking-[-0.03em]">
               <span className="block text-slate-100">{t('hero.line1')}</span>
               <span
-                className="block -mb-[0.12em] pb-[0.12em]"
+                className="-mb-[0.12em] block pb-[0.12em]"
                 style={{
                   background: `linear-gradient(120deg, ${accent}, ${accentB})`,
                   backgroundClip: 'text',
@@ -220,7 +220,7 @@ export default function Hero({
             </h1>
           </Reveal>
 
-          <Reveal delay={160}>
+          <Reveal eager delay={160}>
             <div className="mt-8 max-w-xl">
               <RotatingRole accent={accent} />
               <p className="mt-5 text-[15.5px] leading-relaxed text-slate-300/90">
@@ -229,7 +229,7 @@ export default function Hero({
             </div>
           </Reveal>
 
-          <Reveal delay={240}>
+          <Reveal eager delay={240}>
             <div className="mt-10 flex flex-wrap items-center gap-3">
               <a
                 href="#projects"
@@ -300,7 +300,7 @@ export default function Hero({
           </Reveal>
         </div>
 
-        <Reveal delay={320} y={32}>
+        <Reveal eager delay={320} y={32}>
           <HeroPanel accent={accent} accentB={accentB} />
         </Reveal>
       </div>

--- a/src/components/portfolio/atoms.tsx
+++ b/src/components/portfolio/atoms.tsx
@@ -64,15 +64,22 @@ export const Reveal = ({
   delay = 0,
   y = 24,
   className = '',
+  eager = false,
 }: {
   children: React.ReactNode;
   delay?: number;
   y?: number;
   className?: string;
+  /** Skip the scroll-triggered hide/fade-in — for content already in the
+   * initial viewport (e.g. the hero), where "revealing on scroll" is
+   * meaningless and only delays paint until hydration + IntersectionObserver
+   * fire. */
+  eager?: boolean;
 }) => {
   const ref = useRef<HTMLDivElement>(null);
-  const [shown, setShown] = useState(false);
+  const [shown, setShown] = useState(eager);
   useEffect(() => {
+    if (eager) return undefined;
     const el = ref.current;
     if (!el) return undefined;
     const io = new IntersectionObserver(
@@ -88,16 +95,20 @@ export const Reveal = ({
     );
     io.observe(el);
     return () => io.disconnect();
-  }, []);
+  }, [eager]);
   return (
     <div
       ref={ref}
       className={className}
-      style={{
-        transform: shown ? 'translateY(0)' : `translateY(${y}px)`,
-        opacity: shown ? 1 : 0,
-        transition: `all 0.9s cubic-bezier(.2,.7,.2,1) ${delay}ms`,
-      }}
+      style={
+        eager
+          ? undefined
+          : {
+              transform: shown ? 'translateY(0)' : `translateY(${y}px)`,
+              opacity: shown ? 1 : 0,
+              transition: `all 0.9s cubic-bezier(.2,.7,.2,1) ${delay}ms`,
+            }
+      }
     >
       {children}
     </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,6 +16,7 @@ const fontVariables = `${spaceGrotesk.variable} ${jetbrainsMono.variable}`;
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const [loading, setLoading] = React.useState(true);
+  const { googleAnalytics } = getEnvProperties();
 
   useEffect(() => {
     // Dark-only design: lock the theme.
@@ -35,7 +36,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       <div className={fontVariables}>
         {loading ? <LoadingScreen /> : <Component {...pageProps} />}
         <Analytics />
-        <GoogleAnalytics gaId={getEnvProperties().googleAnalytics} />
+        {googleAnalytics && <GoogleAnalytics gaId={googleAnalytics} />}
       </div>
     </ConfigProvider>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import '../styles/global.css';
-import 'node_modules/flag-icons/css/flag-icons.min.css';
 
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Analytics } from '@vercel/analytics/next';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,10 @@ import { appWithTranslation } from 'next-i18next';
 import React, { useEffect } from 'react';
 
 import LoadingScreen from '@/components/LoadingScreen';
+import { jetbrainsMono, spaceGrotesk } from '@/styles/fonts';
 import { getEnvProperties } from '@/utils';
+
+const fontVariables = `${spaceGrotesk.variable} ${jetbrainsMono.variable}`;
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const [loading, setLoading] = React.useState(true);
@@ -29,9 +32,11 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
         algorithm: theme.darkAlgorithm,
       }}
     >
-      {loading ? <LoadingScreen /> : <Component {...pageProps} />}
-      <Analytics />
-      <GoogleAnalytics gaId={getEnvProperties().googleAnalytics} />
+      <div className={fontVariables}>
+        {loading ? <LoadingScreen /> : <Component {...pageProps} />}
+        <Analytics />
+        <GoogleAnalytics gaId={getEnvProperties().googleAnalytics} />
+      </div>
     </ConfigProvider>
   );
 };

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-/* eslint-disable @next/next/no-css-tags */
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 const i18nextConfig = require('../../next-i18next.config');
@@ -14,16 +13,6 @@ class MyDocument extends Document {
       <Html lang={currentLocale}>
         <>
           <Head>
-            <link rel="preconnect" href="https://fonts.googleapis.com" />
-            <link
-              rel="preconnect"
-              href="https://fonts.gstatic.com"
-              crossOrigin="anonymous"
-            />
-            <link
-              href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
-              rel="stylesheet"
-            />
             <script
               // Dark-only design: lock the theme before first paint.
               dangerouslySetInnerHTML={{

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,18 @@
+import { JetBrains_Mono, Space_Grotesk } from 'next/font/google';
+
+// Self-hosted via next/font instead of a <link> to fonts.googleapis.com: the
+// files are downloaded at build time and served from the app's own origin,
+// so there's no third-party request (and no failure mode) at runtime.
+export const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-space-grotesk',
+  display: 'swap',
+});
+
+export const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,6 +172,16 @@ textarea:focus {
     opacity: 0;
   }
 }
+@keyframes loadingTextIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 
 ::selection {
   background: color-mix(in srgb, var(--accent) 35%, transparent);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,18 +54,18 @@ html {
 }
 
 body {
-  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-family: var(--font-space-grotesk), system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
 
 .font-display {
-  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-family: var(--font-space-grotesk), system-ui, sans-serif;
   font-feature-settings: 'ss01';
 }
 .font-mono {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
 }
 
 a {
@@ -225,7 +225,7 @@ section[id] {
 .prose-body h2,
 .prose-body h3,
 .prose-body h4 {
-  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-family: var(--font-space-grotesk), system-ui, sans-serif;
   color: var(--text-strong);
   letter-spacing: -0.02em;
   margin: 1.6em 0 0.6em;
@@ -273,7 +273,7 @@ section[id] {
   position: absolute;
   left: 0;
   top: 0.05em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-jetbrains-mono), monospace;
   font-size: 0.8em;
   color: var(--accent);
   letter-spacing: 0.05em;
@@ -290,7 +290,7 @@ section[id] {
   margin: 1.5em 0;
 }
 .prose-body :not(pre) > code {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
   font-size: 0.9em;
   padding: 0.1em 0.4em;
   border-radius: 6px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,10 +20,9 @@ const config = {
     },
     fontFamily: {
       agustina: ['Agustina Regular'],
-      sans: ['Space Grotesk', 'system-ui', 'sans-serif'],
-      display: ['Space Grotesk', 'system-ui', 'sans-serif'],
-      mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
-      serifDisplay: ['Instrument Serif', 'Georgia', 'serif'],
+      sans: ['var(--font-space-grotesk)', 'system-ui', 'sans-serif'],
+      display: ['var(--font-space-grotesk)', 'system-ui', 'sans-serif'],
+      mono: ['var(--font-jetbrains-mono)', 'ui-monospace', 'monospace'],
     },
     extend: {
       colors: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8460,11 +8460,6 @@ findup-sync@^4.0.0:
     micromatch "^4.0.2"
     resolve-dir "^1.0.1"
 
-flag-icons@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/flag-icons/-/flag-icons-7.1.0.tgz"
-  integrity sha512-AH4v++19bpC5P3Wh767top4wylJYJCWkFnvNiDqGHDxqSqdMZ49jpLXp8PWBHTTXaNQ+/A+QPrOwyiIGaiIhmw==
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,7 +37,7 @@
   resolved "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz"
   integrity sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==
 
-"@ant-design/icons@^5.0.0", "@ant-design/icons@^5.2.6":
+"@ant-design/icons@^5.2.6":
   version "5.6.1"
   resolved "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz"
   integrity sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==
@@ -8572,15 +8572,6 @@ fraction.js@^4.2.0:
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-framer-motion@^12.35.2:
-  version "12.35.2"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.35.2.tgz#add40fe8cdb8eb553feb9dd17525c93b51e6f67c"
-  integrity sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA==
-  dependencies:
-    motion-dom "^12.35.2"
-    motion-utils "^12.29.2"
-    tslib "^2.4.0"
-
 fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
@@ -12530,18 +12521,6 @@ moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
-
-motion-dom@^12.35.2:
-  version "12.35.2"
-  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.35.2.tgz#489b9eb7206dbac3d6087aae584f08e78c16cfbd"
-  integrity sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg==
-  dependencies:
-    motion-utils "^12.29.2"
-
-motion-utils@^12.29.2:
-  version "12.29.2"
-  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.29.2.tgz#8fdd28babe042c2456b078ab33b32daa3bf5938b"
-  integrity sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==
 
 mrmime@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Summary
- Add a `.github/workflows/lighthouse.yml` workflow (`yarn lighthouse` on push/PR to `main`/`next`) and a dedicated `test.yml` workflow so the README's `Tests` badge isn't coupled to the `deploy` job's SSH step, which has been failing on infra (missing/unreachable deploy secrets) for months, unrelated to code health.
- Add a **Browser Support** section documenting the `browserslist` targets and the concrete Firefox/Safari CSS fallbacks already in the codebase.
- **Set up mobile Lighthouse auditing** (`lighthouserc.mobile.js`, alongside the existing desktop-only config) — mobile had never been run before and came in at **80 performance** vs 97 desktop.
- Gave mobile a real optimization pass rather than just reporting the number:
  - Self-hosted fonts via `next/font/google` instead of a `<link>` to `fonts.googleapis.com` (also dropped an entirely unused Instrument Serif family).
  - Added an `eager` mode to `Reveal` and applied it to the hero — it was the LCP element (4.0s!), stuck behind a scroll-triggered fade-in for content that's fully above the fold on load.
  - Removed `framer-motion` and `@ant-design/icons` (both only used by the pre-hydration loading spinner) — `_app.js` dropped 133 kB → 88.3 kB.
  - Removed an unused global `flag-icons` stylesheet — shared CSS dropped 13.5 kB → 6.83 kB.
  - Pointed the audit at canonical trailing-slash URLs to stop counting a `trailingSlash: true` redirect as 610ms of "waste."
- Final scores — **Desktop: 100/100/96/100**, **Mobile: 88/100/96/100** (perf/a11y/best-practices/seo). Best Practices is capped at 96 in this sandboxed CI-like environment specifically due to blocked/uncredentialed third-party requests (Google Tag Manager, our own API proxy routes without local API keys, Vercel Insights outside actual Vercel hosting) — not real code defects; documented in the README.

## Test plan
- [x] `yarn lighthouse` (both desktop + mobile) run locally end-to-end multiple times to source and verify every number in this PR
- [x] `yarn check-types` / `yarn test` (80/80) pass after each change
- [x] Confirmed `_app.js`/shared-CSS size reduction via `next build` output
- [ ] Confirm `Tests` and `Lighthouse CI` workflows pass on this PR
