### PR TITLE
docs: mark Firefox and Safari as unsupported for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ Enforced in CI via the **Lighthouse CI** workflow (badge above) on every push/PR
 
 ## Browser Support
 
-Targets are defined by the [`browserslist`](package.json) config (`> 0.5%, last 2 versions, not dead, not ie 11, not op_mini all`) and enforced at build time via Autoprefixer/PostCSS.
+Targets are defined by the [`browserslist`](package.json) config and enforced at build time via Autoprefixer/PostCSS.
 
 | Browser | Notes |
 |---------|-------|
-| Chrome / Edge (Chromium) | Primary development and testing target |
-| Firefox | Supported — includes Firefox-specific CSS fallbacks (`scrollbar-width`, native `background-clip: text`, `-moz-osx-font-smoothing`) |
-| Safari (macOS / iOS) | Supported — includes `-webkit-` prefixes for `backdrop-filter` and gradient text |
+| Chrome / Edge (Chromium) | ✅ Supported — primary development and testing target |
+| Firefox (desktop) | ⚠️ **Not officially supported for now** — noticeable scroll/animation jank (likely `backdrop-filter`/`filter: blur()` compositing cost on the animated background and glass-card surfaces) that hasn't been resolved yet |
+| Safari (macOS / iOS) | ⚠️ **Not officially supported for now** — not verified against real hardware; excluded alongside Firefox out of caution rather than a confirmed issue |
 
-Internet Explorer 11 and Opera Mini are explicitly excluded.
+Firefox and Safari are explicitly excluded from the `browserslist` targets while this is being worked on, alongside Internet Explorer 11 and Opera Mini. This is a temporary state, not a permanent decision — revisit once the Firefox performance issue is diagnosed and fixed.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
     "last 2 versions",
     "not dead",
     "not ie 11",
-    "not op_mini all"
+    "not op_mini all",
+    "not firefox > 0",
+    "not and_ff > 0",
+    "not safari > 0",
+    "not ios_saf > 0"
   ]
 }


### PR DESCRIPTION
## Summary
- The earlier scroll-jank fix attempt (#70, pausing the background animation during scroll) didn't resolve the reported Firefox desktop lag when checked on real hardware. This sandbox has no Firefox binary to iterate against directly, so continuing to guess isn't productive right now.
- Exclude `firefox`, `and_ff`, `safari`, and `ios_saf` from the `browserslist` targets in `package.json` (verified with `npx browserslist` that no matching entries remain in the resolved list).
- Update the README's **Browser Support** section: Chrome/Edge stays the supported target; Firefox and Safari are marked `⚠️ Not officially supported for now`, with the reasoning for each (Firefox: confirmed unresolved jank; Safari: never verified on real hardware, excluded out of caution).
- This is framed as temporary — to revisit once the underlying Firefox performance issue is actually diagnosed (most likely a `backdrop-filter`/`filter: blur()` compositing cost, but unconfirmed).

## Test plan
- [x] `npx browserslist` confirms no firefox/safari/ios_saf/and_ff entries in the resolved target list
- [x] `yarn check-types` / `yarn test` (88/88) / `yarn build` all pass — the browserslist change doesn't break the Autoprefixer/PostCSS build


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPQ5UmSifArdSWXiBbcpKv)_